### PR TITLE
Fix auth package to handle fetching token on GCE

### DIFF
--- a/api/pkg/auth/google_auth.go
+++ b/api/pkg/auth/google_auth.go
@@ -51,9 +51,15 @@ func (s *idTokenSource) Token() (*oauth2.Token, error) {
 // InitGoogleClient is a helper method to be used by CaraML components to initialise a Google Client that appends ID
 // tokens to the headers of all outgoing requests, regardless of the type of credentials used
 func InitGoogleClient(ctx context.Context) (*http.Client, error) {
+	// this method is called to check the type of service account specified in the credentials
 	cred, err := google.FindDefaultCredentials(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Case when default credentials are not specified in GOOGLE_APPLICATION_CREDENTIALS env var
+	if len(cred.JSON) == 0 {
+		return idtoken.NewClient(ctx, defaultCaraMLAudience)
 	}
 
 	var f credentialsFile


### PR DESCRIPTION
### Summary
This PR checks if the `Creds` object created has an empty JSON byte slice before attempting to unmarshal the byte slice to construct a http client. 

The use case is to handle cases when the default credentials are not obtained from `GOOGLE_APPLICATION_CREDENTIALS`, but other sources like the GCE Metadata server. See [here](https://github.com/golang/oauth2/blob/cfe200d5bb2f300f7e51d5259d993d035b3d11b3/google/default.go#L32) for complete explanation.

Without this check, the error `panic: unexpected end of JSON input` will be thrown.