### PR TITLE
feat: Add caching for authorization checks

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,6 +22,7 @@ on:
 
 env:
   GO_VERSION: "1.20"
+  GO_LINT_VERSION: v1.51.2
   NODE_VERSION: 16
   ARTIFACT_RETENTION_DAYS: 7
   CONTAINER_REGISTRY: ghcr.io
@@ -114,7 +115,12 @@ jobs:
           restore-keys: gomod-
 
       - name: Lint code
-        run: make lint-api
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: ${{ env.GO_LINT_VERSION }}
+          working-directory: api
+          skip-go-installation: true
+          args: --timeout 3m --verbose
 
       - name: Run Integration Test
         run: make it-test-api

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: "1.20"
   NODE_VERSION: 16
   ARTIFACT_RETENTION_DAYS: 7
   CONTAINER_REGISTRY: ghcr.io

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -118,9 +118,8 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: ${{ env.GO_LINT_VERSION }}
-          working-directory: api
           skip-go-installation: true
-          args: --timeout 3m --verbose
+          args: --timeout 3m --verbose api/...
 
       - name: Run Integration Test
         run: make it-test-api

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # Binary directory
 bin/
+
+# Vendor directory
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn app build
 # ============================================================
 # Build stage 2: Build API
 # ============================================================
-FROM golang:1.18-alpine as go-builder
+FROM golang:1.20-alpine as go-builder
 WORKDIR /src/api
 COPY api api/
 COPY go.mod .

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ fmt:
 .PHONY: lint-api
 lint-api: setup
 	@echo "Linting code..."
-	golangci-lint -v run --timeout 3m $(if $(filter true,$(fix)),--fix,) ${API_PATH}/...
+	golangci-lint -v run --timeout 5m $(if $(filter true,$(fix)),--fix,) ${API_PATH}/...
 
 # ============================================================
 # Testing recipes

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ init-dep-ui:
 .PHONY: init-dep-api
 init-dep-api:
 	@echo "> Initializing API dependencies ..."
-	@cd ${API_PATH} && go mod tidy -v
 	@cd ${API_PATH} && go get -v ./...
 
 # ============================================================

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ fmt:
 .PHONY: lint-api
 lint-api: setup
 	@echo "Linting code..."
-	golangci-lint -v run --timeout 5m $(if $(filter true,$(fix)),--fix,) ${API_PATH}/...
+	golangci-lint -v run --timeout 3m $(if $(filter true,$(fix)),--fix,) ${API_PATH}/...
 
 # ============================================================
 # Testing recipes

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as go-builder
+FROM golang:1.20-alpine as go-builder
 
 WORKDIR /src/api
 

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -40,10 +40,14 @@ type AppContext struct {
 func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error) {
 	var authEnforcer enforcer.Enforcer
 	if cfg.Authorization.Enabled {
-		authEnforcer, err = enforcer.NewEnforcerBuilder().
-			URL(cfg.Authorization.KetoServerURL).
-			Product("mlp").
-			Build()
+		enforcerCfg := enforcer.NewEnforcerBuilder().URL(cfg.Authorization.KetoServerURL).Product("mlp")
+		if cfg.Authorization.Caching.Enabled {
+			enforcerCfg = enforcerCfg.WithCaching(
+				cfg.Authorization.Caching.KeyExpirySeconds,
+				cfg.Authorization.Caching.CacheCleanUpIntervalSeconds,
+			)
+		}
+		authEnforcer, err = enforcerCfg.Build()
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize authorization service: %v", err)

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -88,7 +88,14 @@ type DatabaseConfig struct {
 
 type AuthorizationConfig struct {
 	Enabled       bool
-	KetoServerURL string `validate:"required_if=Enabled True"`
+	KetoServerURL string               `validate:"required_if=Enabled True"`
+	Caching       *InMemoryCacheConfig `validate:"required_if=Enabled True"`
+}
+
+type InMemoryCacheConfig struct {
+	Enabled                     bool
+	KeyExpirySeconds            int `validate:"required_if=Enabled True"`
+	CacheCleanUpIntervalSeconds int `validate:"required_if=Enabled True"`
 }
 
 type MlflowConfig struct {
@@ -188,6 +195,10 @@ var defaultConfig = &Config{
 
 	Authorization: &AuthorizationConfig{
 		Enabled: false,
+		Caching: &InMemoryCacheConfig{
+			KeyExpirySeconds:            600,
+			CacheCleanUpIntervalSeconds: 900,
+		},
 	},
 	Database: &DatabaseConfig{
 		Host:          "localhost",

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -18,6 +18,10 @@ applications:
 authorization:
   enabled: true
   ketoServerURL: http://localhost:4466
+  caching:
+    enabled: true
+    keyExpirySeconds: 1000
+    cacheCleanUpIntervalSeconds: 2000
 
 ui:
   clockworkUIHomepage: http://clockwork.dev

--- a/api/pkg/authz/enforcer/builder.go
+++ b/api/pkg/authz/enforcer/builder.go
@@ -6,10 +6,11 @@ import (
 
 // Builder builder of enforcer.Enforcer
 type Builder struct {
-	url     string
-	product string
-	flavor  Flavor
-	timeout time.Duration
+	url         string
+	product     string
+	flavor      Flavor
+	timeout     time.Duration
+	cacheConfig *CacheConfig
 }
 
 const (
@@ -54,7 +55,15 @@ func (b *Builder) Timeout(timeout time.Duration) *Builder {
 	return b
 }
 
+func (b *Builder) WithCaching(keyExpirySeconds int, cacheCleanUpIntervalSeconds int) *Builder {
+	b.cacheConfig = &CacheConfig{
+		KeyExpirySeconds:            keyExpirySeconds,
+		CacheCleanUpIntervalSeconds: cacheCleanUpIntervalSeconds,
+	}
+	return b
+}
+
 // Build build an enforcer.Enforcer instance
 func (b *Builder) Build() (Enforcer, error) {
-	return newEnforcer(b.url, b.product, b.flavor, b.timeout)
+	return newEnforcer(b.url, b.product, b.flavor, b.timeout, b.cacheConfig)
 }

--- a/api/pkg/authz/enforcer/cache.go
+++ b/api/pkg/authz/enforcer/cache.go
@@ -1,0 +1,102 @@
+package enforcer
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/ory/keto-client-go/models"
+	cache "github.com/patrickmn/go-cache"
+)
+
+type InMemoryCache struct {
+	store *cache.Cache
+
+	mapLock sync.Mutex
+
+	// Instead of caching the full names of the subject, resource and action, ids will be
+	// generated (using an incrementing counter) for each unique value. This will aid in
+	// generating smaller cache keys.
+	// The following maps store the mapping of the name -> internal id.
+	subjectMap  map[string]string
+	resourceMap map[string]string
+	actionMap   map[string]string
+}
+
+func newInMemoryCache(keyExpirySeconds int, cacheCleanUpIntervalSeconds int) *InMemoryCache {
+	return &InMemoryCache{
+		store: cache.New(
+			time.Duration(keyExpirySeconds)*time.Second,
+			time.Duration(cacheCleanUpIntervalSeconds)*time.Second,
+		),
+		subjectMap:  map[string]string{},
+		resourceMap: map[string]string{},
+		actionMap:   map[string]string{},
+	}
+}
+
+func (c *InMemoryCache) LookUpPermission(input models.OryAccessControlPolicyAllowedInput) (*bool, bool) {
+	if cachedValue, ok := c.store.Get(c.buildCacheKey(input)); ok {
+		if allowed, ok := cachedValue.(*bool); ok {
+			return allowed, true
+		}
+	}
+	return nil, false
+}
+
+func (c *InMemoryCache) StorePermission(input models.OryAccessControlPolicyAllowedInput, isAllowed *bool) {
+	c.store.Set(c.buildCacheKey(input), isAllowed, cache.DefaultExpiration)
+}
+
+func (c *InMemoryCache) buildCacheKey(input models.OryAccessControlPolicyAllowedInput) string {
+	return fmt.Sprintf("%s:%s:%s",
+		c.getActionID(input.Action),
+		c.getSubjectID(input.Subject),
+		c.getResourceID(input.Resource),
+	)
+}
+
+func (c *InMemoryCache) getSubjectID(name string) string {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+
+	if val, ok := c.subjectMap[name]; ok {
+		return val
+	}
+	newID := strconv.Itoa(countMapKeys(c.subjectMap) + 1)
+	c.subjectMap[name] = newID
+	return newID
+}
+
+func (c *InMemoryCache) getResourceID(name string) string {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+
+	if val, ok := c.resourceMap[name]; ok {
+		return val
+	}
+	newID := strconv.Itoa(countMapKeys(c.resourceMap) + 1)
+	c.resourceMap[name] = newID
+	return newID
+}
+
+func (c *InMemoryCache) getActionID(name string) string {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+
+	if val, ok := c.actionMap[name]; ok {
+		return val
+	}
+	newID := strconv.Itoa(countMapKeys(c.actionMap) + 1)
+	c.actionMap[name] = newID
+	return newID
+}
+
+func countMapKeys(m map[string]string) int {
+	count := 0
+	for range m {
+		count++
+	}
+	return count
+}

--- a/api/pkg/authz/enforcer/cache.go
+++ b/api/pkg/authz/enforcer/cache.go
@@ -19,9 +19,9 @@ type InMemoryCache struct {
 	// generated (using an incrementing counter) for each unique value. This will aid in
 	// generating smaller cache keys.
 	// The following maps store the mapping of the name -> internal id.
-	subjectMap  map[string]string
-	resourceMap map[string]string
 	actionMap   map[string]string
+	resourceMap map[string]string
+	subjectMap  map[string]string
 }
 
 func newInMemoryCache(keyExpirySeconds int, cacheCleanUpIntervalSeconds int) *InMemoryCache {
@@ -30,9 +30,9 @@ func newInMemoryCache(keyExpirySeconds int, cacheCleanUpIntervalSeconds int) *In
 			time.Duration(keyExpirySeconds)*time.Second,
 			time.Duration(cacheCleanUpIntervalSeconds)*time.Second,
 		),
-		subjectMap:  map[string]string{},
-		resourceMap: map[string]string{},
 		actionMap:   map[string]string{},
+		resourceMap: map[string]string{},
+		subjectMap:  map[string]string{},
 	}
 }
 
@@ -52,8 +52,8 @@ func (c *InMemoryCache) StorePermission(input models.OryAccessControlPolicyAllow
 func (c *InMemoryCache) buildCacheKey(input models.OryAccessControlPolicyAllowedInput) string {
 	return fmt.Sprintf("%s:%s:%s",
 		c.getActionID(input.Action),
-		c.getSubjectID(input.Subject),
 		c.getResourceID(input.Resource),
+		c.getSubjectID(input.Subject),
 	)
 }
 

--- a/api/pkg/authz/enforcer/cache_test.go
+++ b/api/pkg/authz/enforcer/cache_test.go
@@ -1,0 +1,175 @@
+package enforcer
+
+import (
+	"testing"
+
+	"github.com/ory/keto-client-go/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCacheKey(t *testing.T) {
+	tests := map[string]struct {
+		cache    *InMemoryCache
+		input    models.OryAccessControlPolicyAllowedInput
+		expected string
+	}{
+		"first item": {
+			cache: &InMemoryCache{
+				actionMap:   map[string]string{},
+				resourceMap: map[string]string{},
+				subjectMap:  map[string]string{},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "abc",
+				Resource: "def",
+				Subject:  "xyz",
+			},
+			expected: "1:1:1",
+		},
+		"all items exist": {
+			cache: &InMemoryCache{
+				actionMap: map[string]string{
+					"abc": "2",
+				},
+				resourceMap: map[string]string{
+					"def": "4",
+				},
+				subjectMap: map[string]string{
+					"xyz": "10",
+				},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "abc",
+				Resource: "def",
+				Subject:  "xyz",
+			},
+			expected: "2:4:10",
+		},
+		"some items exist": {
+			cache: &InMemoryCache{
+				actionMap: map[string]string{
+					"abc": "0",
+				},
+				resourceMap: map[string]string{
+					"def": "4",
+				},
+				subjectMap: map[string]string{
+					"xyz": "0",
+				},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "abc",
+				Resource: "abc",
+				Subject:  "xyz",
+			},
+			expected: "0:2:0", // Resource ID (missing) will be generated using the map key count
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.cache.buildCacheKey(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestLookUp(t *testing.T) {
+	trueValue, falseValue := true, false
+	type seedData struct {
+		item      models.OryAccessControlPolicyAllowedInput
+		isAllowed *bool
+	}
+
+	tests := map[string]struct {
+		seedData      []seedData
+		input         models.OryAccessControlPolicyAllowedInput
+		expectedVal   *bool
+		expectedFound bool
+	}{
+		"item exists | true value": {
+			seedData: []seedData{
+				{
+					item: models.OryAccessControlPolicyAllowedInput{
+						Action:   "abc",
+						Resource: "def",
+						Subject:  "xyz",
+					},
+					isAllowed: &trueValue,
+				},
+				{
+					item: models.OryAccessControlPolicyAllowedInput{
+						Action:   "def",
+						Resource: "ghi",
+						Subject:  "xyz",
+					},
+					isAllowed: &falseValue,
+				},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "abc",
+				Resource: "def",
+				Subject:  "xyz",
+			},
+			expectedVal:   &trueValue,
+			expectedFound: true,
+		},
+		"item exists | false value": {
+			seedData: []seedData{
+				{
+					item: models.OryAccessControlPolicyAllowedInput{
+						Action:   "abc",
+						Resource: "def",
+						Subject:  "xyz",
+					},
+					isAllowed: &trueValue,
+				},
+				{
+					item: models.OryAccessControlPolicyAllowedInput{
+						Action:   "def",
+						Resource: "ghi",
+						Subject:  "xyz",
+					},
+					isAllowed: &falseValue,
+				},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "def",
+				Resource: "ghi",
+				Subject:  "xyz",
+			},
+			expectedVal:   &falseValue,
+			expectedFound: true,
+		},
+		"item does not exist": {
+			seedData: []seedData{
+				{
+					item: models.OryAccessControlPolicyAllowedInput{
+						Action:   "abc",
+						Resource: "def",
+						Subject:  "xyz",
+					},
+					isAllowed: &trueValue,
+				},
+			},
+			input: models.OryAccessControlPolicyAllowedInput{
+				Action:   "def",
+				Resource: "ghi",
+				Subject:  "xyz",
+			},
+			expectedFound: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newInMemoryCache(60, 60)
+			for _, item := range tt.seedData {
+				cache.StorePermission(item.item, item.isAllowed)
+			}
+			cachedVal, found := cache.LookUpPermission(tt.input)
+			assert.Equal(t, tt.expectedVal, cachedVal)
+			assert.Equal(t, tt.expectedFound, found)
+		})
+	}
+}

--- a/api/pkg/authz/enforcer/enforcer.go
+++ b/api/pkg/authz/enforcer/enforcer.go
@@ -306,7 +306,12 @@ func (e *enforcer) isAllowed(user string, resource string, action string) (*bool
 		}
 	}
 
-	return res.GetPayload().Allowed, nil
+	// Save to cache and return
+	allowed := res.GetPayload().Allowed
+	if e.isCacheEnabled() {
+		e.cache.Set(cacheKey, allowed, cache.DefaultExpiration)
+	}
+	return allowed, nil
 }
 
 func (e *enforcer) formatUser(user string) string {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caraml-dev/mlp
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.29.0
@@ -107,6 +107,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/ory/keto-client-go v0.4.4-alpha.1 h1:eQkXvjovJkqFHawMJYZBUa1CdTQicVjs
 github.com/ory/keto-client-go v0.4.4-alpha.1/go.mod h1:v13bI95oapu8Qh+i3E0y6mtezkVK6SMNzX2l04+0NOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
### Motivation

This PR adds an in-memory cache for the authorization checks. The purpose of this cache is to reduce the load on the underlying authz API server, given that these mappings rarely change.

### Implementation

#### api/pkg/authz

A simple map-based in-memory caching mechanism is introduced in `api/pkg/authz/enforcer/enforcer.go`, which stores the result (true/false) of each `action:subject:resource` combination that is checked for.

The cache itself is implemented in `api/pkg/authz/enforcer/cache.go` and includes some minor optimization on the cache key used (mapping action/subject/resource names to auto-generated IDs) so that the data stored in the cache is concise.
Eg: `GET:firstname.lastname@domain.com:projects` -> `1:1:2`

```
Note: Without this optimization, in the example shown below for MLP, we will be needing ~250 MiB of memory.
```

If the cache is enabled on the Enforcer, it will be initialised and used as a read-aside cache. The key expiration and cache clean up interval are configurable.

This package is used in multiple CaraML components such as the MLP API (changes described below), Turing, Merlin, etc. If the in-memory cache is enabled, the onus is on the consumers of this package to:
* Ensure that sufficient run-time memory is allocated for the app, depending on the expected usage.
* Determine how the cache can be leveraged efficiently. Eg: If access is always granted to resource `a` and `a:**` together (and there are no DENY permissions involved), when the app must check for permissions on `a:b:c`, it can instead decide to check for the permission on `a` only, to reduce the number of unique cache keys created.

#### api/api

* `api/config/config.go` - Add config options for using caching with the authz layer
* `api/middleware/authorization.go` - Manipulate the resource names to only run checks against the first 2 levels. This is sufficient because most permissions are granted project-wide (with the exception of the `/applications` API, which doesn't have any sub-resources).
* `api/api/router.go` - Enable authz caching

```
Memory implications
===================
Turning on the authz caching will have the following memory implications. With:
* 100 users => ~ 2 x 100 bytes ID data = 200
* 5 commonly used methods (GET, POST, PUT, PATCH, DELETE) => 1 x 5 bytes ID data = 5
* 100 projects (i.e., 100 `projects:{id}` resources) => 2 x 100 bytes ID data = 200
* 2 simple resources (`applications`, `projects`) => 2 x 2 bytes ID data = 4

We could be storing up to:
200 x 5 x (200 + 4) bytes = ~ 204 KiB of data in-memory.
```

### Next steps

* Add UI config and changes to warn users that permission changes may take up to X minutes to take effect, when authz caching is enabled.

### Other changes

* Upgrade to Go 1.20
* Update API lint step in CI to use `golanci-lint` action directly