### PR TITLE
feat: UI changes for Authz caching

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -61,16 +61,21 @@ func main() {
 	}
 	mount(router, "/v2", api.NewRouter(appCtx, v2Controllers))
 
+	var maxCacheExpiryMinutes string
+	if cfg.Authorization.Enabled && cfg.Authorization.Caching != nil && cfg.Authorization.Caching.Enabled {
+		maxCacheExpiryMinutes = fmt.Sprintf("%.0f",
+			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes()))
+	}
+
 	uiEnv := uiEnvHandler{
-		APIURL:        cfg.APIHost,
-		OauthClientID: cfg.OauthClientID,
-		Environment:   cfg.Environment,
-		SentryDSN:     cfg.SentryDSN,
-		Streams:       cfg.Streams,
-		Docs:          cfg.Docs,
-		MaxAuthzCacheExpiryMinutes: fmt.Sprintf("%.0f",
-			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes())),
-		UIConfig: cfg.UI,
+		APIURL:                     cfg.APIHost,
+		OauthClientID:              cfg.OauthClientID,
+		Environment:                cfg.Environment,
+		SentryDSN:                  cfg.SentryDSN,
+		Streams:                    cfg.Streams,
+		Docs:                       cfg.Docs,
+		MaxAuthzCacheExpiryMinutes: maxCacheExpiryMinutes,
+		UIConfig:                   cfg.UI,
 	}
 
 	router.Methods("GET").Path("/env.js").HandlerFunc(uiEnv.handler)

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -100,7 +100,7 @@ type uiEnvHandler struct {
 	SentryDSN                  string                `json:"REACT_APP_SENTRY_DSN,omitempty"`
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
-	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
+	MaxAuthzCacheExpiryMinutes string
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -61,21 +61,16 @@ func main() {
 	}
 	mount(router, "/v2", api.NewRouter(appCtx, v2Controllers))
 
-	var maxCacheExpiryMinutes string
-	if cfg.Authorization.Enabled && cfg.Authorization.Caching != nil && cfg.Authorization.Caching.Enabled {
-		maxCacheExpiryMinutes = fmt.Sprintf("%.0f",
-			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes()))
-	}
-
 	uiEnv := uiEnvHandler{
-		APIURL:                     cfg.APIHost,
-		OauthClientID:              cfg.OauthClientID,
-		Environment:                cfg.Environment,
-		SentryDSN:                  cfg.SentryDSN,
-		Streams:                    cfg.Streams,
-		Docs:                       cfg.Docs,
-		MaxAuthzCacheExpiryMinutes: maxCacheExpiryMinutes,
-		UIConfig:                   cfg.UI,
+		APIURL:        cfg.APIHost,
+		OauthClientID: cfg.OauthClientID,
+		Environment:   cfg.Environment,
+		SentryDSN:     cfg.SentryDSN,
+		Streams:       cfg.Streams,
+		Docs:          cfg.Docs,
+		MaxAuthzCacheExpiryMinutes: fmt.Sprintf("%.0f",
+			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes())),
+		UIConfig: cfg.UI,
 	}
 
 	router.Methods("GET").Path("/env.js").HandlerFunc(uiEnv.handler)

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -105,7 +105,7 @@ type uiEnvHandler struct {
 	SentryDSN                  string                `json:"REACT_APP_SENTRY_DSN,omitempty"`
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
-	MaxAuthzCacheExpiryMinutes string
+	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -190,9 +190,9 @@ var defaultConfig = &Config{
 	Environment: "dev",
 	Port:        8080,
 
-	Streams: Streams{},
-	Docs:    Documentations{},
-
+	Streams:      Streams{},
+	Docs:         Documentations{},
+	Applications: []modelsv2.Application{},
 	Authorization: &AuthorizationConfig{
 		Enabled: false,
 		Caching: &InMemoryCacheConfig{

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -76,8 +76,9 @@ func TestLoad(t *testing.T) {
 					MaxIdleConns:    10,
 					MaxOpenConns:    20,
 				},
-				Mlflow: &config.MlflowConfig{},
-				Docs:   []config.Documentation{},
+				Mlflow:       &config.MlflowConfig{},
+				Docs:         []config.Documentation{},
+				Applications: []modelsv2.Application{},
 				Streams: map[string][]string{
 					"stream-1":     {"team-a", "team-b"},
 					"SecondStream": {"MyTeam"},
@@ -132,8 +133,9 @@ func TestLoad(t *testing.T) {
 					MaxIdleConns:    10,
 					MaxOpenConns:    20,
 				},
-				Mlflow: &config.MlflowConfig{},
-				Docs:   []config.Documentation{},
+				Mlflow:       &config.MlflowConfig{},
+				Docs:         []config.Documentation{},
+				Applications: []modelsv2.Application{},
 				Streams: map[string][]string{
 					"stream-1":     {"team-a", "team-b"},
 					"SecondStream": {"MyTeam"},

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/newrelic/go-agent v3.19.2+incompatible
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/ory/keto-client-go v0.4.4-alpha.1
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
@@ -107,7 +108,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,10 @@ github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
@@ -173,6 +175,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -19,12 +19,18 @@ const config = {
         "https://github.com/caraml-dev/merlin/blob/main/docs/getting-started/README.md",
       label: "Merlin User Guide"
     },
-    { href: "https://github.com/caraml-dev/turing", label: "Turing User Guide" },
+    {
+      href: "https://github.com/caraml-dev/turing",
+      label: "Turing User Guide"
+    },
     {
       href: "https://docs.feast.dev/user-guide/overview",
       label: "Feast User Guide"
     }
   ],
+  MAX_AUTHZ_CACHE_EXPIRY_MINUTES: parseInt(
+    getEnv("REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES") || "0"
+  ),
 
   CLOCKWORK_UI_HOMEPAGE: getEnv("REACT_APP_CLOCKWORK_UI_HOMEPAGE"),
   KUBEFLOW_UI_HOMEPAGE: getEnv("REACT_APP_KUBEFLOW_UI_HOMEPAGE")

--- a/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
+++ b/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
@@ -79,6 +79,7 @@ const SubmitUserRoleForm = ({ userRole, project, fetchUpdates, toggleAdd }) => {
     onChange
   ]);
 
+  const isAuthzCacheEnabled = !!config.MAX_AUTHZ_CACHE_EXPIRY_MINUTES;
   return (
     <EuiPanel paddingSize="m">
       <EuiFlexGroup justifyContent="spaceAround" direction="column">
@@ -127,10 +128,19 @@ const SubmitUserRoleForm = ({ userRole, project, fetchUpdates, toggleAdd }) => {
           </EuiForm>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiCallOut
-            title={`Permission changes may take up to ${config.MAX_AUTHZ_CACHE_EXPIRY_MINUTES} minutes to take effect in all components.`}
-            iconType="iInCircle"
-          />
+          {isAuthzCacheEnabled && (
+            <EuiCallOut
+              title={`Permission changes may take up to ${
+                config.MAX_AUTHZ_CACHE_EXPIRY_MINUTES
+              }
+                ${
+                  config.MAX_AUTHZ_CACHE_EXPIRY_MINUTES > 1
+                    ? "minutes"
+                    : "minute"
+                } to take effect in all components.`}
+              iconType="iInCircle"
+            />
+          )}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup direction="row">

--- a/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
+++ b/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -14,6 +15,7 @@ import {
   EuiTitle,
   EuiToolTip
 } from "@elastic/eui";
+import config from "../../config";
 import { validateEmail } from "../../validation/validation";
 import { addToast, useMlpApi } from "@caraml-dev/ui-lib";
 import UserRoleSelection from "./UserRoleSelection";
@@ -123,6 +125,12 @@ const SubmitUserRoleForm = ({ userRole, project, fetchUpdates, toggleAdd }) => {
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiForm>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCallOut
+            title={`Permission changes may take up to ${config.MAX_AUTHZ_CACHE_EXPIRY_MINUTES} minutes to take effect in all components.`}
+            iconType="iInCircle"
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup direction="row">


### PR DESCRIPTION
This MR mainly adds a small UI change to warn the users that, when _updating_ permissions for a project, changes may take up to `X` minutes to take effect in the individual components. Since the individual components may set any value for [KeyExpirySeconds](https://github.com/caraml-dev/mlp/blob/main/api/pkg/authz/enforcer/enforcer.go#L47), a new `MaxKeyExpirySeconds` has been introduced in `api/pkg/authz/enforcer/enforcer.go` which is hard-coded to 10 minutes. This means that, components will not be allowed to set key expiry > this value (this will be the `X`).

### Illustration
<img width="924" alt="Screenshot 2023-06-11 at 7 38 53 PM" src="https://github.com/caraml-dev/mlp/assets/23465343/0db48e4d-29c4-4c17-befc-dcbc14596361">

### Changes
* `api/cmd/main.go` - Supply UI env var `REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES`. When doing this, whether Authz and caching are enabled on the MLP app does not matter because they could be turned off on MLP but turned on in Turing, Merlin, etc.
* `api/pkg/authz/enforcer/enforcer.go` - Add `MaxKeyExpirySeconds` and a check to ensure that, when initialising the enforcer, the configured `KeyExpirySeconds` cannot be larger.
* `ui/packages/app/src/config.js` - Add `MAX_AUTHZ_CACHE_EXPIRY_MINUTES` config
* `ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js` - Add info in the edit user permissions form