### PR TITLE
bugfix: existing role permissions should not be removed during update

### DIFF
--- a/api/pkg/authz/enforcer/enforcer.go
+++ b/api/pkg/authz/enforcer/enforcer.go
@@ -240,16 +240,6 @@ func (e *enforcer) UpdateAuthorization(ctx context.Context, updateRequest Author
 		return err
 	}
 	patches := make([]ory.RelationshipPatch, 0)
-	existingRolePermissions.Range(func(key, value interface{}) bool {
-		role := key.(string)
-		permissions := value.([]string)
-		for _, permission := range permissions {
-			if !slices.Contains(updateRequest.RolePermissions[role], permission) {
-				patches = append(patches, newRolePermissionPatch("delete", permission, role))
-			}
-		}
-		return true
-	})
 
 	for role, permissions := range updateRequest.RolePermissions {
 		for _, permission := range permissions {
@@ -291,7 +281,7 @@ func (e *enforcer) isCacheEnabled() bool {
 }
 
 // NewAuthorizationUpdateRequest create a new AuthorizationUpdateRequest. Multiple operations can be chained together
-// using the SetRolePermissions and SetRoleMembers methods. No changes will be made until the AuthorizationUpdateRequest
+// using the AddRolePermissions and SetRoleMembers methods. No changes will be made until the AuthorizationUpdateRequest
 // object is passed to the Enforcer, in which all the previously chained operations will be executed in batch.
 func NewAuthorizationUpdateRequest() AuthorizationUpdateRequest {
 	return AuthorizationUpdateRequest{
@@ -305,8 +295,8 @@ type AuthorizationUpdateRequest struct {
 	RoleMembers     map[string][]string
 }
 
-// SetRolePermissions set the permissions for a role. If the role already has permissions, they will be replaced.
-func (a AuthorizationUpdateRequest) SetRolePermissions(role string,
+// AddRolePermissions add permissions to a role, without duplication. Existing permissions will still be in place.
+func (a AuthorizationUpdateRequest) AddRolePermissions(role string,
 	permissions []string) AuthorizationUpdateRequest {
 	a.RolePermissions[role] = permissions
 	return a

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -144,7 +144,7 @@ func (service *projectsService) updateAuthorizationPolicy(ctx context.Context, p
 		return err
 	}
 	for _, role := range rolesWithReadOnlyAccess {
-		updateRequest.SetRolePermissions(role, readPermissions(project))
+		updateRequest.AddRolePermissions(role, readPermissions(project))
 	}
 	projectAdminRole, err := enforcer.ParseProjectRole(enforcer.MLPProjectAdminRole, project)
 	if err != nil {
@@ -164,7 +164,7 @@ func (service *projectsService) updateAuthorizationPolicy(ctx context.Context, p
 		return err
 	}
 	for _, role := range rolesWithAdminAccess {
-		updateRequest.SetRolePermissions(role, adminPermissions(project))
+		updateRequest.AddRolePermissions(role, adminPermissions(project))
 	}
 	projectReaderRole, err := enforcer.ParseProjectRole(enforcer.MLPProjectReaderRole, project)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	go.uber.org/zap v1.17.0
@@ -105,7 +106,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect


### PR DESCRIPTION
Currently, existing permissions of a role is removed before the new ones are inserted. This behaviour is fine for project administrator and reader roles, but problematic for mlp administrator roles. As present, if someone update or create a new project, the mlp administrator role will gain the permissions of the new/updated project, but lost every other access.

After this fix, existing permissions will not be removed during an authorization update. The method has also been renamed for better clarity of the intention.