### PR TITLE
fix: labelling bug in UI when editing user roles

### DIFF
--- a/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
+++ b/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
@@ -210,11 +210,14 @@ function convertRequestToJSONPayload(request, project) {
     copyOfProject[fieldRole] = roleUsers;
   });
 
-  return {
+  const payload = {
     name: copyOfProject.name,
     administrators: copyOfProject.administrators,
     readers: copyOfProject.readers,
     stream: copyOfProject.stream,
     team: copyOfProject.team
   };
+  return copyOfProject.labels
+    ? { ...payload, labels: copyOfProject.labels }
+    : payload;
 }

--- a/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
+++ b/ui/packages/app/src/project_setting/user_role/SubmitUserRoleForm.js
@@ -209,15 +209,12 @@ function convertRequestToJSONPayload(request, project) {
     }
     copyOfProject[fieldRole] = roleUsers;
   });
-
-  const payload = {
+  return {
     name: copyOfProject.name,
     administrators: copyOfProject.administrators,
     readers: copyOfProject.readers,
     stream: copyOfProject.stream,
-    team: copyOfProject.team
+    team: copyOfProject.team,
+    labels: copyOfProject.labels
   };
-  return copyOfProject.labels
-    ? { ...payload, labels: copyOfProject.labels }
-    : payload;
 }


### PR DESCRIPTION
### Summary
* When user roles are updated, the labels in the project are not included in the request body sent to mlp api
* This causes the updated project to not have any labels
* The fix is to set the labels field if it exists
* This only occurs for create/update user roles. For delete roles this bug does not occur.