### PR TITLE
Make update project settings endpoint call URL with template payload + add a labels blacklist

### DIFF
--- a/api/api/api_test.go
+++ b/api/api/api_test.go
@@ -62,9 +62,9 @@ func (s *APITestSuite) SetupTest() {
 			Endpoint:         "",
 			PayloadTemplate:  "template-payload",
 			ResponseTemplate: "template-response",
-			LabelsBlacklist: map[string]bool{
-				"label1": true,
-				"label2": true,
+			LabelsBlacklist: []string{
+				"label1",
+				"label2",
 			},
 		},
 		DefaultSecretStorage: &config.SecretStorage{

--- a/api/api/api_test.go
+++ b/api/api/api_test.go
@@ -58,7 +58,7 @@ func (s *APITestSuite) SetupTest() {
 		Mlflow: &config.MlflowConfig{
 			TrackingURL: "http://mlflow:5000",
 		},
-		UpdateProject: &config.UpdateProjectConfig{
+		UpdateProjectConfig: &config.UpdateProjectConfig{
 			Endpoint:         "",
 			PayloadTemplate:  "template-payload",
 			ResponseTemplate: "template-response",

--- a/api/api/api_test.go
+++ b/api/api/api_test.go
@@ -58,11 +58,6 @@ func (s *APITestSuite) SetupTest() {
 		Mlflow: &config.MlflowConfig{
 			TrackingURL: "http://mlflow:5000",
 		},
-		UpdateProject: &config.UpdateProjectConfig{
-			Endpoint:         "",
-			PayloadTemplate:  "template-payload",
-			ResponseTemplate: "template-response",
-		},
 		DefaultSecretStorage: &config.SecretStorage{
 			Name: "vault",
 			Type: string(models.VaultSecretStorageType),

--- a/api/api/api_test.go
+++ b/api/api/api_test.go
@@ -58,6 +58,15 @@ func (s *APITestSuite) SetupTest() {
 		Mlflow: &config.MlflowConfig{
 			TrackingURL: "http://mlflow:5000",
 		},
+		UpdateProject: &config.UpdateProjectConfig{
+			Endpoint:         "",
+			PayloadTemplate:  "template-payload",
+			ResponseTemplate: "template-response",
+			LabelsBlacklist: map[string]bool{
+				"label1": true,
+				"label2": true,
+			},
+		},
 		DefaultSecretStorage: &config.SecretStorage{
 			Name: "vault",
 			Type: string(models.VaultSecretStorageType),

--- a/api/api/api_test.go
+++ b/api/api/api_test.go
@@ -58,6 +58,11 @@ func (s *APITestSuite) SetupTest() {
 		Mlflow: &config.MlflowConfig{
 			TrackingURL: "http://mlflow:5000",
 		},
+		UpdateProject: &config.UpdateProjectConfig{
+			Endpoint:         "",
+			PayloadTemplate:  "template-payload",
+			ResponseTemplate: "template-response",
+		},
 		DefaultSecretStorage: &config.SecretStorage{
 			Name: "vault",
 			Type: string(models.VaultSecretStorageType),

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -78,19 +78,17 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 	project.Team = newProject.Team
 	project.Stream = newProject.Stream
 	project.Labels = newProject.Labels
-	updatedProject, responseMessage, err := c.ProjectsService.UpdateProject(r.Context(), project)
+	project, response, err := c.ProjectsService.UpdateProject(r.Context(), project)
+	if project == nil {
+		log.Errorf("project %s is not updated", project)
+		return FromError(err)
+	}
 	if err != nil {
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)
 	}
 
-	if responseMessage != "" {
-		log.Infof("Project updated successfully, URL link: %s", responseMessage)
-	} else {
-		log.Infof("Project updated successfully")
-	}
-
-	return Ok(updatedProject)
+	return Ok(response)
 }
 
 func (c *ProjectsController) GetProject(r *http.Request, vars map[string]string, body interface{}) *Response {

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -87,6 +87,10 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)
 	}
+	if response == nil {
+		log.Errorf("error updating project, update project config has not been completely specified")
+		return FromError(err)
+	}
 
 	return Ok(response)
 }

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -90,9 +90,9 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 
 	if response != nil {
 		return Ok(response)
-	} else {
-		return Ok(project)
 	}
+
+	return Ok(project)
 }
 
 func (c *ProjectsController) GetProject(r *http.Request, vars map[string]string, body interface{}) *Response {

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -78,7 +78,7 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 	project.Team = newProject.Team
 	project.Stream = newProject.Stream
 	project.Labels = newProject.Labels
-	project, response, err := c.ProjectsService.UpdateProject(r.Context(), project)
+	updatedProject, response, err := c.ProjectsService.UpdateProject(r.Context(), project)
 	if err != nil {
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)
@@ -88,7 +88,7 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 		return Ok(response)
 	}
 
-	return Ok(project)
+	return Ok(updatedProject)
 }
 
 func (c *ProjectsController) GetProject(r *http.Request, vars map[string]string, body interface{}) *Response {

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -87,12 +87,12 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)
 	}
-	if response == nil {
-		log.Errorf("error updating project, update project config has not been completely specified")
-		return FromError(err)
-	}
 
-	return Ok(response)
+	if response != nil {
+		return Ok(response)
+	} else {
+		return Ok(project)
+	}
 }
 
 func (c *ProjectsController) GetProject(r *http.Request, vars map[string]string, body interface{}) *Response {

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -78,13 +78,14 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 	project.Team = newProject.Team
 	project.Stream = newProject.Stream
 	project.Labels = newProject.Labels
-	project, err = c.ProjectsService.UpdateProject(r.Context(), project)
+	updatedProject, responseMessage, err := c.ProjectsService.UpdateProject(r.Context(), project)
 	if err != nil {
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)
 	}
 
-	return Ok(project)
+	log.Infof("Project updated successfully, URL link: %s", responseMessage)
+	return Ok(updatedProject)
 }
 
 func (c *ProjectsController) GetProject(r *http.Request, vars map[string]string, body interface{}) *Response {

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -84,7 +84,12 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 		return FromError(err)
 	}
 
-	log.Infof("Project updated successfully, URL link: %s", responseMessage)
+	if responseMessage != "" {
+		log.Infof("Project updated successfully, URL link: %s", responseMessage)
+	} else {
+		log.Infof("Project updated successfully")
+	}
+
 	return Ok(updatedProject)
 }
 

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -79,10 +79,6 @@ func (c *ProjectsController) UpdateProject(r *http.Request, vars map[string]stri
 	project.Stream = newProject.Stream
 	project.Labels = newProject.Labels
 	project, response, err := c.ProjectsService.UpdateProject(r.Context(), project)
-	if project == nil {
-		log.Errorf("project %s is not updated", project)
-		return FromError(err)
-	}
 	if err != nil {
 		log.Errorf("error updating project %s: %s", project.Name, err)
 		return FromError(err)

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -482,10 +482,12 @@ func TestUpdateProject(t *testing.T) {
 					assert.NoError(t, err)
 
 					w.WriteHeader(http.StatusOK)
-					json.NewEncoder(w).Encode(map[string]interface{}{
+					response := map[string]string{
 						"status":  "success",
 						"message": "Project updated successfully",
-					})
+					}
+					err = json.NewEncoder(w).Encode(response)
+					assert.NoError(t, err)
 				}))
 				defer server.Close()
 

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -408,7 +408,9 @@ func TestUpdateProject(t *testing.T) {
 				Stream:         "dsp",
 				Administrators: []string{adminUser},
 			},
-			expectedResponse: nil,
+			expectedResponse: &Response{
+				code: 200,
+			},
 			expectedMessage: map[string]interface{}{
 				"status":  "success",
 				"message": "Project updated successfully",
@@ -605,7 +607,7 @@ func TestUpdateProject(t *testing.T) {
 
 				assert.Equal(t, tC.expectedResponse.code, rr.Code)
 				if tC.expectedResponse.code >= 200 && tC.expectedResponse.code < 300 {
-					if tC.expectedResponse != nil {
+					if tC.expectedResponse.data != nil {
 						project := &models.Project{}
 						err = json.Unmarshal(rr.Body.Bytes(), &project)
 						assert.NoError(t, err)

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -206,7 +206,7 @@ func TestCreateProject(t *testing.T) {
 					_, err := prjRepository.Save(tC.existingProject)
 					assert.NoError(t, err)
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil)
+				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, "", "", "")
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{
@@ -316,7 +316,7 @@ func TestListProjects(t *testing.T) {
 						assert.NoError(t, err)
 					}
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil)
+				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, "", "", "")
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{
@@ -479,7 +479,7 @@ func TestUpdateProject(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var payload map[string]interface{}
 					err := json.NewDecoder(r.Body).Decode(&payload)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 
 					w.WriteHeader(http.StatusOK)
 					json.NewEncoder(w).Encode(map[string]interface{}{
@@ -621,7 +621,7 @@ func TestGetProject(t *testing.T) {
 					_, err := prjRepository.Save(tC.existingProject)
 					assert.NoError(t, err)
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil)
+				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, "", "", "")
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -207,7 +207,10 @@ func TestCreateProject(t *testing.T) {
 					_, err := prjRepository.Save(tC.existingProject)
 					assert.NoError(t, err)
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, nil)
+				projectService, err := service.NewProjectsService(
+					mlflowTrackingURL, prjRepository, nil, false, nil,
+					config.UpdateProjectConfig{},
+				)
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{
@@ -317,7 +320,10 @@ func TestListProjects(t *testing.T) {
 						assert.NoError(t, err)
 					}
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, nil)
+				projectService, err := service.NewProjectsService(
+					mlflowTrackingURL, prjRepository, nil, false, nil,
+					config.UpdateProjectConfig{},
+				)
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{
@@ -415,7 +421,7 @@ func TestUpdateProject(t *testing.T) {
 					},
 				},
 			},
-			updateProjectEndpoint: server.URL,
+			updateProjectEndpoint: "url",
 			updateProjectPayload: `{
 				"project": "{{.Name}}",
 				"administrators": "{{.Administrators}}",
@@ -685,7 +691,10 @@ func TestGetProject(t *testing.T) {
 					_, err := prjRepository.Save(tC.existingProject)
 					assert.NoError(t, err)
 				}
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, nil)
+				projectService, err := service.NewProjectsService(
+					mlflowTrackingURL, prjRepository, nil, false, nil,
+					config.UpdateProjectConfig{},
+				)
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -559,7 +559,7 @@ func TestUpdateProject(t *testing.T) {
 				Administrators: []string{adminUser},
 			},
 			expectedResponse: &Response{
-				code: 400,
+				code: 500,
 				data: ErrorMessage{
 					Message: "one or more labels are blacklisted or have been removed or changed values and cannot be updated",
 				},

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -424,9 +424,9 @@ func TestUpdateProject(t *testing.T) {
 					"status": "{{.status}}",
 					"message": "{{.message}}"
 				}`,
-				LabelsBlacklist: map[string]bool{
-					"label1": true,
-					"label2": true,
+				LabelsBlacklist: []string{
+					"label1",
+					"label2",
 				},
 			},
 		},
@@ -565,8 +565,8 @@ func TestUpdateProject(t *testing.T) {
 				},
 			},
 			updateProjectConfig: config.UpdateProjectConfig{
-				LabelsBlacklist: map[string]bool{
-					"my-label": true,
+				LabelsBlacklist: []string{
+					"my-label",
 				},
 			},
 		},

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -504,7 +504,11 @@ func TestUpdateProject(t *testing.T) {
 					"message": "{{.message}}"
 				}`
 
-				projectService, err := service.NewProjectsService(mlflowTrackingURL, prjRepository, nil, false, nil, updateProjectEndpoint, updateProjectPayloadTemplate, updateProjectResponseTemplate)
+				projectsService, err := service.NewProjectsService(
+					mlflowTrackingURL, prjRepository, nil, false, nil
+					updateProjectEndpoint, updateProjectPayloadTemplate,
+					updateProjectResponseTemplate,
+				)
 				assert.NoError(t, err)
 
 				appCtx := &AppContext{

--- a/api/api/projects_api_test.go
+++ b/api/api/projects_api_test.go
@@ -497,14 +497,14 @@ func TestUpdateProject(t *testing.T) {
 					"administrators": "{{.Administrators}}",
 					"readers": "{{.Readers}}",
 					"team": "{{.Team}}",
-					"stream": "{{.Stream}}",
+					"stream": "{{.Stream}}"
 				}`
 				updateProjectResponseTemplate := `{
 					"status": "{{.status}}",
 					"message": "{{.message}}"
 				}`
 
-				projectsService, err := service.NewProjectsService(
+				projectService, err := service.NewProjectsService(
 					mlflowTrackingURL, prjRepository, nil, false, nil
 					updateProjectEndpoint, updateProjectPayloadTemplate,
 					updateProjectResponseTemplate,

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -70,7 +70,10 @@ func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error)
 		}
 	}
 
-	var updateProjectConfig config.UpdateProjectConfig
+	if cfg.UpdateProject == nil {
+		return nil, fmt.Errorf("update project config is nil")
+	}
+	updateProjectConfig := *cfg.UpdateProject
 
 	projectsService, err := service.NewProjectsService(
 		cfg.Mlflow.TrackingURL,

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -70,17 +70,12 @@ func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error)
 		}
 	}
 
-	if cfg.UpdateProject == nil {
-		return nil, fmt.Errorf("update project config is nil")
-	}
-	updateProjectConfig := *cfg.UpdateProject
-
 	projectsService, err := service.NewProjectsService(
 		cfg.Mlflow.TrackingURL,
 		repository.NewProjectRepository(db),
 		authEnforcer,
 		cfg.Authorization.Enabled, projectsWebhookManager,
-		updateProjectConfig)
+		*cfg.UpdateProject)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize projects service: %v", err)

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -70,14 +70,14 @@ func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error)
 		}
 	}
 
+	var updateProjectConfig config.UpdateProjectConfig
+
 	projectsService, err := service.NewProjectsService(
 		cfg.Mlflow.TrackingURL,
 		repository.NewProjectRepository(db),
 		authEnforcer,
 		cfg.Authorization.Enabled, projectsWebhookManager,
-		cfg.UpdateProject.Endpoint,
-		cfg.UpdateProject.PayloadTemplate,
-		cfg.UpdateProject.ResponseTemplate)
+		updateProjectConfig)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize projects service: %v", err)

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -75,7 +75,7 @@ func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error)
 		repository.NewProjectRepository(db),
 		authEnforcer,
 		cfg.Authorization.Enabled, projectsWebhookManager,
-		*cfg.UpdateProject)
+		*cfg.UpdateProjectConfig)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize projects service: %v", err)

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -74,7 +74,10 @@ func NewAppContext(db *gorm.DB, cfg *config.Config) (ctx *AppContext, err error)
 		cfg.Mlflow.TrackingURL,
 		repository.NewProjectRepository(db),
 		authEnforcer,
-		cfg.Authorization.Enabled, projectsWebhookManager)
+		cfg.Authorization.Enabled, projectsWebhookManager,
+		cfg.UpdateProject.Endpoint,
+		cfg.UpdateProject.PayloadTemplate,
+		cfg.UpdateProject.ResponseTemplate)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize projects service: %v", err)

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -115,7 +115,7 @@ type uiEnvHandler struct {
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
 	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
-	LabelsBlacklist            map[string]bool       `json:"REACT_APP_LABELS_BLACKLIST"`
+	LabelsBlacklist            []string              `json:"REACT_APP_LABELS_BLACKLIST"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -83,7 +83,7 @@ func startServer(cfg *config.Config) {
 		Docs:          cfg.Docs,
 		MaxAuthzCacheExpiryMinutes: fmt.Sprintf("%.0f",
 			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes())),
-		LabelsBlacklist: cfg.UpdateProject.LabelsBlacklist,
+		LabelsBlacklist: cfg.UpdateProjectConfig.LabelsBlacklist,
 		UIConfig:        cfg.UI,
 	}
 

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -115,7 +115,7 @@ type uiEnvHandler struct {
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
 	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
-	LabelsBlacklist            []string              `json:"REACT_APP_LABELS_BLACKLIST"`
+	LabelsBlacklist            map[string]bool       `json:"REACT_APP_LABELS_BLACKLIST"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -83,8 +83,8 @@ func startServer(cfg *config.Config) {
 		Docs:          cfg.Docs,
 		MaxAuthzCacheExpiryMinutes: fmt.Sprintf("%.0f",
 			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes())),
-		LabelsBlacklist:          cfg.UpdateProject.LabelsBlacklist,
-		UIConfig: cfg.UI,
+		LabelsBlacklist: cfg.UpdateProject.LabelsBlacklist,
+		UIConfig:        cfg.UI,
 	}
 
 	router.Methods("GET").Path("/env.js").HandlerFunc(uiEnv.handler)
@@ -115,7 +115,7 @@ type uiEnvHandler struct {
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
 	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
-	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"`
+	LabelsBlacklist            []string              `json:"REACT_APP_LABELS_BLACKLIST"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -83,6 +83,7 @@ func startServer(cfg *config.Config) {
 		Docs:          cfg.Docs,
 		MaxAuthzCacheExpiryMinutes: fmt.Sprintf("%.0f",
 			math.Ceil((time.Duration(enforcer.MaxKeyExpirySeconds) * time.Second).Minutes())),
+		LabelsBlacklist:          cfg.UpdateProject.LabelsBlacklist,
 		UIConfig: cfg.UI,
 	}
 
@@ -114,6 +115,7 @@ type uiEnvHandler struct {
 	Streams                    config.Streams        `json:"REACT_APP_STREAMS"`
 	Docs                       config.Documentations `json:"REACT_APP_DOC_LINKS"`
 	MaxAuthzCacheExpiryMinutes string                `json:"REACT_APP_MAX_AUTHZ_CACHE_EXPIRY_MINUTES"`
+	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -131,7 +131,7 @@ type UpdateProjectConfig struct {
 	Endpoint         string `validate:"url"`
 	PayloadTemplate  string
 	ResponseTemplate string
-	LabelsBlacklist  []string // labels blacklist that hides/prevents labels contained within to not be modifiable
+	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"` // labels blacklist that hides/prevents labels contained within to not be modifiable
 }
 
 // Transform env variables to the format consumed by koanf.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -233,6 +233,12 @@ var defaultConfig = &Config{
 		AllowCustomTeam:   true,
 		AllowCustomStream: true,
 	},
+	UpdateProject: &UpdateProjectConfig{
+		Endpoint:         "http://localhost:8080",
+		PayloadTemplate:  ``,
+		ResponseTemplate: ``,
+		LabelsBlacklist:  []string{"env"},
+	},
 	DefaultSecretStorage: &SecretStorage{
 		Name: "internal",
 		Type: "internal",

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -128,10 +128,10 @@ type UIConfig struct {
 }
 
 type UpdateProjectConfig struct {
-	Endpoint         string
+	Endpoint         string `validate:"url"`
 	PayloadTemplate  string
 	ResponseTemplate string
-	LabelsBlacklist  []string
+	LabelsBlacklist  []string // labels blacklist that hides/prevents labels contained within to not be modifiable
 }
 
 // Transform env variables to the format consumed by koanf.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -128,10 +128,10 @@ type UIConfig struct {
 }
 
 type UpdateProjectConfig struct {
-	Endpoint         string `validate:"url"`
+	Endpoint         string `validate:"omitempty,url"`
 	PayloadTemplate  string
 	ResponseTemplate string
-	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"`
+	LabelsBlacklist  map[string]bool
 	// labels blacklist that hides/prevents labels contained within to not be modifiable
 }
 
@@ -233,12 +233,7 @@ var defaultConfig = &Config{
 		AllowCustomTeam:   true,
 		AllowCustomStream: true,
 	},
-	UpdateProject: &UpdateProjectConfig{
-		Endpoint:         "http://localhost:8080",
-		PayloadTemplate:  ``,
-		ResponseTemplate: ``,
-		LabelsBlacklist:  []string{"env"},
-	},
+	UpdateProject: &UpdateProjectConfig{},
 	DefaultSecretStorage: &SecretStorage{
 		Name: "internal",
 		Type: "internal",

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -136,7 +136,7 @@ type UpdateProjectConfig struct {
 	// through the template that should be sent back to the user
 	ResponseTemplate string
 	// labels blacklist that hides/prevents labels contained within to not be modifiable
-	LabelsBlacklist map[string]bool
+	LabelsBlacklist []string
 }
 
 // Transform env variables to the format consumed by koanf.

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	DefaultSecretStorage *SecretStorage         `validate:"required"`
 	UI                   *UIConfig
 	Webhooks             *webhooks.Config
-	UpdateProject        *UpdateProjectConfig `validate:"required"`
+	UpdateProject        *UpdateProjectConfig
 }
 
 // SecretStorage represents the configuration for a secret storage.
@@ -128,10 +128,10 @@ type UIConfig struct {
 }
 
 type UpdateProjectConfig struct {
-	UpdateProjectEndpoint        string `validate:"required,url"`
-	UpdateProjectPayload         string `validate:"required"`
-	UpdateProjectResponse        string `validate:"required"`
-	UpdateProjectLabelsBlacklist []string
+	Endpoint         string `validate:"url"`
+	PayloadTemplate  string
+	ResponseTemplate string
+	LabelsBlacklist  []string
 }
 
 // Transform env variables to the format consumed by koanf.
@@ -231,12 +231,6 @@ var defaultConfig = &Config{
 		StaticPath:        "ui/build",
 		AllowCustomTeam:   true,
 		AllowCustomStream: true,
-	},
-	UpdateProject: &UpdateProjectConfig{
-		UpdateProjectEndpoint:        "",
-		UpdateProjectPayload:         `{}`,
-		UpdateProjectResponse:        `{}`,
-		UpdateProjectLabelsBlacklist: []string{"team_id"},
 	},
 	DefaultSecretStorage: &SecretStorage{
 		Name: "internal",

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	DefaultSecretStorage *SecretStorage         `validate:"required"`
 	UI                   *UIConfig
 	Webhooks             *webhooks.Config
-	UpdateProject        *UpdateProjectConfig
+	UpdateProjectConfig  *UpdateProjectConfig
 }
 
 // SecretStorage represents the configuration for a secret storage.
@@ -128,11 +128,15 @@ type UIConfig struct {
 }
 
 type UpdateProjectConfig struct {
-	Endpoint         string `validate:"omitempty,url"`
-	PayloadTemplate  string
+	// endpoint to be called when the update projects config endpoint is called
+	Endpoint string `validate:"omitempty,url"`
+	// payload template to define the payload in a JSON template to be sent to the endpoint
+	PayloadTemplate string
+	// response template to define the response in the JSON payload given by the endpoint
+	// through the template that should be sent back to the user
 	ResponseTemplate string
-	LabelsBlacklist  map[string]bool
 	// labels blacklist that hides/prevents labels contained within to not be modifiable
+	LabelsBlacklist map[string]bool
 }
 
 // Transform env variables to the format consumed by koanf.
@@ -233,7 +237,7 @@ var defaultConfig = &Config{
 		AllowCustomTeam:   true,
 		AllowCustomStream: true,
 	},
-	UpdateProject: &UpdateProjectConfig{},
+	UpdateProjectConfig: &UpdateProjectConfig{},
 	DefaultSecretStorage: &SecretStorage{
 		Name: "internal",
 		Type: "internal",

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -128,7 +128,7 @@ type UIConfig struct {
 }
 
 type UpdateProjectConfig struct {
-	Endpoint         string `validate:"url"`
+	Endpoint         string
 	PayloadTemplate  string
 	ResponseTemplate string
 	LabelsBlacklist  []string

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DefaultSecretStorage *SecretStorage         `validate:"required"`
 	UI                   *UIConfig
 	Webhooks             *webhooks.Config
+	UpdateProject        *UpdateProjectConfig `validate:"required"`
 }
 
 // SecretStorage represents the configuration for a secret storage.
@@ -124,6 +125,13 @@ type UIConfig struct {
 	AllowCustomStream        bool `json:"REACT_APP_ALLOW_CUSTOM_STREAM"`
 	AllowCustomTeam          bool `json:"REACT_APP_ALLOW_CUSTOM_TEAM"`
 	ProjectInfoUpdateEnabled bool `json:"REACT_APP_PROJECT_INFO_UPDATE_ENABLED"`
+}
+
+type UpdateProjectConfig struct {
+	UpdateProjectEndpoint        string `validate:"required,url"`
+	UpdateProjectPayload         string `validate:"required"`
+	UpdateProjectResponse        string `validate:"required"`
+	UpdateProjectLabelsBlacklist []string
 }
 
 // Transform env variables to the format consumed by koanf.
@@ -223,6 +231,12 @@ var defaultConfig = &Config{
 		StaticPath:        "ui/build",
 		AllowCustomTeam:   true,
 		AllowCustomStream: true,
+	},
+	UpdateProject: &UpdateProjectConfig{
+		UpdateProjectEndpoint:        "",
+		UpdateProjectPayload:         `{}`,
+		UpdateProjectResponse:        `{}`,
+		UpdateProjectLabelsBlacklist: []string{"team_id"},
 	},
 	DefaultSecretStorage: &SecretStorage{
 		Name: "internal",

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -131,7 +131,8 @@ type UpdateProjectConfig struct {
 	Endpoint         string `validate:"url"`
 	PayloadTemplate  string
 	ResponseTemplate string
-	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"` // labels blacklist that hides/prevents labels contained within to not be modifiable
+	LabelsBlacklist  []string `json:"REACT_APP_LABELS_BLACKLIST"`
+	// labels blacklist that hides/prevents labels contained within to not be modifiable
 }
 
 // Transform env variables to the format consumed by koanf.

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -90,7 +90,7 @@ func TestLoad(t *testing.T) {
 					AllowCustomTeam:   true,
 					AllowCustomStream: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "",
 					PayloadTemplate:  "",
 					ResponseTemplate: "",
@@ -155,7 +155,7 @@ func TestLoad(t *testing.T) {
 					AllowCustomTeam:   true,
 					AllowCustomStream: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "",
 					PayloadTemplate:  "",
 					ResponseTemplate: "",
@@ -260,7 +260,7 @@ func TestLoad(t *testing.T) {
 					AllowCustomStream:        true,
 					ProjectInfoUpdateEnabled: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint: "http://localhost:3030",
 					PayloadTemplate: `{"template": "{{.template}}"}
 `,
@@ -355,7 +355,7 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
@@ -411,7 +411,7 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
@@ -471,7 +471,7 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
@@ -528,7 +528,7 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
-				UpdateProject: &config.UpdateProjectConfig{
+				UpdateProjectConfig: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -266,9 +266,9 @@ func TestLoad(t *testing.T) {
 `,
 					ResponseTemplate: `{"response": "{{.response}}"}
 `,
-					LabelsBlacklist: map[string]bool{
-						"label1": true,
-						"label2": true,
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
 					},
 				},
 				DefaultSecretStorage: &config.SecretStorage{
@@ -359,9 +359,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: map[string]bool{
-						"label1": true,
-						"label2": true,
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
 					},
 				},
 			},
@@ -415,9 +415,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: map[string]bool{
-						"label1": true,
-						"label2": true,
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
 					},
 				},
 			},
@@ -475,9 +475,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: map[string]bool{
-						"label1": true,
-						"label2": true,
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
 					},
 				},
 			},
@@ -532,9 +532,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: map[string]bool{
-						"label1": true,
-						"label2": true,
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
 					},
 				},
 			},

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -248,6 +248,11 @@ func TestLoad(t *testing.T) {
 					AllowCustomStream:        true,
 					ProjectInfoUpdateEnabled: true,
 				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "http://example-update-project.dev",
+					PayloadTemplate:  "template-payload",
+					ResponseTemplate: "template-response",
+				},
 				DefaultSecretStorage: &config.SecretStorage{
 					Name: "default-secret-storage",
 					Type: "vault",
@@ -332,6 +337,11 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "http://example-update-project.dev",
+					PayloadTemplate:  "template-payload",
+					ResponseTemplate: "template-response",
+				},
 			},
 		},
 		"extended | success": {
@@ -378,6 +388,11 @@ func TestValidate(t *testing.T) {
 				},
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
+				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "http://example-update-project.dev",
+					PayloadTemplate:  "template-payload",
+					ResponseTemplate: "template-response",
 				},
 			},
 		},
@@ -430,6 +445,11 @@ func TestValidate(t *testing.T) {
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
 				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "http://example-update-project.dev",
+					PayloadTemplate:  "template-payload",
+					ResponseTemplate: "template-response",
+				},
 			},
 			error: errors.New(
 				"failed to validate configuration: " +
@@ -477,6 +497,11 @@ func TestValidate(t *testing.T) {
 				},
 				UI: &config.UIConfig{
 					ProjectInfoUpdateEnabled: true,
+				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "http://example-update-project.dev",
+					PayloadTemplate:  "template-payload",
+					ResponseTemplate: "template-response",
 				},
 			},
 			error: errors.New(

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -249,12 +249,14 @@ func TestLoad(t *testing.T) {
 					ProjectInfoUpdateEnabled: true,
 				},
 				UpdateProject: &config.UpdateProjectConfig{
-					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "your-payload-template",
-					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: []string{
-						"label1",
-						"label2",
+					Endpoint: "http://localhost:3030",
+					PayloadTemplate: `{"template": "{{.template}}"}
+`,
+					ResponseTemplate: `{"response": "{{.response}}"}
+`,
+					LabelsBlacklist: map[string]bool{
+						"label1": true,
+						"label2": true,
 					},
 				},
 				DefaultSecretStorage: &config.SecretStorage{
@@ -345,9 +347,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: []string{
-						"label1",
-						"label2",
+					LabelsBlacklist: map[string]bool{
+						"label1": true,
+						"label2": true,
 					},
 				},
 			},
@@ -401,9 +403,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: []string{
-						"label1",
-						"label2",
+					LabelsBlacklist: map[string]bool{
+						"label1": true,
+						"label2": true,
 					},
 				},
 			},
@@ -461,9 +463,9 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist: []string{
-						"label1",
-						"label2",
+					LabelsBlacklist: map[string]bool{
+						"label1": true,
+						"label2": true,
 					},
 				},
 			},
@@ -518,7 +520,10 @@ func TestValidate(t *testing.T) {
 					Endpoint:         "http://example-update-project.dev",
 					PayloadTemplate:  "your-payload-template",
 					ResponseTemplate: "your-response-template",
-					LabelsBlacklist:  []string{},
+					LabelsBlacklist: map[string]bool{
+						"label1": true,
+						"label2": true,
+					},
 				},
 			},
 			error: errors.New(

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -250,8 +250,12 @@ func TestLoad(t *testing.T) {
 				},
 				UpdateProject: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "template-payload",
-					ResponseTemplate: "template-response",
+					PayloadTemplate:  "your-payload-template",
+					ResponseTemplate: "your-response-template",
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
+					},
 				},
 				DefaultSecretStorage: &config.SecretStorage{
 					Name: "default-secret-storage",
@@ -339,8 +343,12 @@ func TestValidate(t *testing.T) {
 				},
 				UpdateProject: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "template-payload",
-					ResponseTemplate: "template-response",
+					PayloadTemplate:  "your-payload-template",
+					ResponseTemplate: "your-response-template",
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
+					},
 				},
 			},
 		},
@@ -391,8 +399,12 @@ func TestValidate(t *testing.T) {
 				},
 				UpdateProject: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "template-payload",
-					ResponseTemplate: "template-response",
+					PayloadTemplate:  "your-payload-template",
+					ResponseTemplate: "your-response-template",
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
+					},
 				},
 			},
 		},
@@ -447,8 +459,12 @@ func TestValidate(t *testing.T) {
 				},
 				UpdateProject: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "template-payload",
-					ResponseTemplate: "template-response",
+					PayloadTemplate:  "your-payload-template",
+					ResponseTemplate: "your-response-template",
+					LabelsBlacklist: []string{
+						"label1",
+						"label2",
+					},
 				},
 			},
 			error: errors.New(
@@ -500,8 +516,9 @@ func TestValidate(t *testing.T) {
 				},
 				UpdateProject: &config.UpdateProjectConfig{
 					Endpoint:         "http://example-update-project.dev",
-					PayloadTemplate:  "template-payload",
-					ResponseTemplate: "template-response",
+					PayloadTemplate:  "your-payload-template",
+					ResponseTemplate: "your-response-template",
+					LabelsBlacklist:  []string{},
 				},
 			},
 			error: errors.New(

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -90,6 +90,12 @@ func TestLoad(t *testing.T) {
 					AllowCustomTeam:   true,
 					AllowCustomStream: true,
 				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "",
+					PayloadTemplate:  "",
+					ResponseTemplate: "",
+					LabelsBlacklist:  nil,
+				},
 				DefaultSecretStorage: &config.SecretStorage{
 					Name: "default-secret-storage",
 					Type: "vault",
@@ -148,6 +154,12 @@ func TestLoad(t *testing.T) {
 					IndexPath:         "index.html",
 					AllowCustomTeam:   true,
 					AllowCustomStream: true,
+				},
+				UpdateProject: &config.UpdateProjectConfig{
+					Endpoint:         "",
+					PayloadTemplate:  "",
+					ResponseTemplate: "",
+					LabelsBlacklist:  nil,
 				},
 				DefaultSecretStorage: &config.SecretStorage{
 					Name: "default-secret-storage",

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -30,7 +30,7 @@ ui:
   kubeflowUIHomepage: http://kubeflow.org
   projectinfoUpdateEnabled: true
 
-updateProject:
+updateProjectConfig:
   endpoint: http://localhost:3030
   payloadTemplate: |
     {"template": "{{.template}}"}

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -31,12 +31,14 @@ ui:
   projectinfoUpdateEnabled: true
 
 updateProject:
-  endpoint: "http://example-update-project.dev"
-  payloadTemplate: "your-payload-template"
-  responseTemplate: "your-response-template"
+  endpoint: http://localhost:3030
+  payloadTemplate: |
+    {"template": "{{.template}}"}
+  responseTemplate: |
+    {"response": "{{.response}}"}
   labelsBlacklist:
-    - "label1"
-    - "label2"
+    label1: true
+    label2: true
 
 defaultSecretStorage:
   name: default-secret-storage

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -32,8 +32,11 @@ ui:
 
 updateProject:
   endpoint: "http://example-update-project.dev"
-  payloadTemplate: "template-payload"
-  responseTemplate: "template-response"
+  payloadTemplate: "your-payload-template"
+  responseTemplate: "your-response-template"
+  labelsBlacklist:
+    - "label1"
+    - "label2"
 
 defaultSecretStorage:
   name: default-secret-storage

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -30,6 +30,11 @@ ui:
   kubeflowUIHomepage: http://kubeflow.org
   projectinfoUpdateEnabled: true
 
+updateProject:
+  endpoint: "http://example-update-project.dev"
+  payloadTemplate: "template-payload"
+  responseTemplate: "template-response"
+
 defaultSecretStorage:
   name: default-secret-storage
   type: vault

--- a/api/config/testdata/config-2.yaml
+++ b/api/config/testdata/config-2.yaml
@@ -37,8 +37,8 @@ updateProjectConfig:
   responseTemplate: |
     {"response": "{{.response}}"}
   labelsBlacklist:
-    label1: true
-    label2: true
+    - label1
+    - label2
 
 defaultSecretStorage:
   name: default-secret-storage

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -372,7 +372,8 @@ func processResponseTemplate(response *http.Response, templateString string) (ma
 }
 
 // areBlacklistedLabelsChanged check if any key in labels is blacklisted
-func (service *projectsService) areBlacklistedLabelsChanged(projectID models.ID, newLabels []models.Label, blacklist map[string]bool) (bool, error) {
+func (service *projectsService) areBlacklistedLabelsChanged(projectID models.ID, newLabels []models.Label,
+	blacklist map[string]bool) (bool, error) {
 	existingProject, err := service.FindByID(projectID)
 	if err != nil {
 		return false, fmt.Errorf("error fetching project with id %s: %w", projectID, err)

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -134,7 +134,8 @@ func (service *projectsService) ListProjects(ctx context.Context, name string, u
 	return allProjects, nil
 }
 
-func (service *projectsService) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, string, error) {
+func (service *projectsService) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, string,
+	error) {
 	if service.authEnabled {
 		err := service.updateAuthorizationPolicy(ctx, project)
 		if err != nil {

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -139,7 +139,8 @@ func (service *projectsService) UpdateProject(ctx context.Context, project *mode
 	}
 
 	if isLabelBlacklisted(existingProject.Labels, project.Labels, service.updateProjectConfig.LabelsBlacklist) {
-		return nil, nil, fmt.Errorf("one or more labels are blacklisted or have been removed or changed values and cannot be updated")
+		return nil, nil,
+			fmt.Errorf("one or more labels are blacklisted or have been removed or changed values and cannot be updated")
 	}
 
 	if service.webhookManager == nil || !service.webhookManager.IsEventConfigured(ProjectUpdatedEvent) {
@@ -174,7 +175,8 @@ func (service *projectsService) UpdateProject(ctx context.Context, project *mode
 	}, webhooks.NoOpErrorHandler)
 	if err != nil {
 		return project, nil,
-			fmt.Errorf("error while invoking %s webhooks or on success callback function, err: %s", ProjectUpdatedEvent, err.Error())
+			fmt.Errorf("error while invoking %s webhooks or on success callback function, err: %s",
+				ProjectUpdatedEvent, err.Error())
 	}
 
 	if service.updateProjectConfig.Endpoint != "" {
@@ -292,7 +294,8 @@ func (service *projectsService) filterAuthorizedProjects(ctx context.Context, pr
 	return authorizedProjects, nil
 }
 
-func (service *projectsService) handleUpdateProjectRequest(project *models.Project) (*models.Project, map[string]interface{}, error) {
+func (service *projectsService) handleUpdateProjectRequest(project *models.Project) (*models.Project,
+	map[string]interface{}, error) {
 	if service.updateProjectConfig.PayloadTemplate == "" || service.updateProjectConfig.ResponseTemplate == "" {
 		return project, nil, nil
 	}

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -49,9 +49,9 @@ func NewProjectsService(
 		return nil, errors.New("default mlflow tracking url should be provided")
 	}
 
-	blacklistMap := make(map[string]bool)
+	labelsBlacklistMap := make(map[string]bool)
 	for _, key := range updateProjectConfig.LabelsBlacklist {
-		blacklistMap[key] = true
+		labelsBlacklistMap[key] = true
 	}
 
 	return &projectsService{
@@ -63,7 +63,7 @@ func NewProjectsService(
 		updateProjectEndpoint:         updateProjectConfig.Endpoint,
 		updateProjectPayloadTemplate:  updateProjectConfig.PayloadTemplate,
 		updateProjectResponseTemplate: updateProjectConfig.ResponseTemplate,
-		blacklistMap:                  blacklistMap,
+		labelsBlacklistMap:            labelsBlacklistMap,
 	}, nil
 }
 
@@ -76,7 +76,7 @@ type projectsService struct {
 	updateProjectEndpoint         string
 	updateProjectPayloadTemplate  string
 	updateProjectResponseTemplate string
-	blacklistMap                  map[string]bool
+	labelsBlacklistMap            map[string]bool
 }
 
 func (service *projectsService) CreateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
@@ -394,7 +394,7 @@ func (service *projectsService) areBlacklistedLabelsChanged(project *models.Proj
 	}
 
 	for _, existingLabel := range existingProject.Labels {
-		if service.blacklistMap[existingLabel.Key] {
+		if service.labelsBlacklistMap[existingLabel.Key] {
 			newValue, exists := newLabelsMap[existingLabel.Key]
 			if !exists || newValue != existingLabel.Value {
 				return true, nil

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -115,11 +115,11 @@ func TestProjectsService_CreateProject(t *testing.T) {
 			UpdateProjectPayloadTemplate := ""
 			UpdateProjectResponseTemplate := ""
 
-            projectsService, err := NewProjectsService(
-                MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
-                UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
-                UpdateProjectResponseTemplate,
-            )
+			projectsService, err := NewProjectsService(
+				MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
+				UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+				UpdateProjectResponseTemplate,
+			)
 			require.NoError(t, err)
 
 			if tt.expAuthUpdate != nil {
@@ -226,8 +226,8 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 					"status":  "success",
 					"message": "Project updated successfully",
 				}
-                err = json.NewEncoder(w).Encode(response)
-                require.NoError(t, err)
+				err = json.NewEncoder(w).Encode(response)
+				require.NoError(t, err)
 			}))
 			defer server.Close()
 
@@ -245,11 +245,11 @@ func TestProjectsService_UpdateProject(t *testing.T) {
                 "message": "{{.message}}"
             }`
 
-            projectsService, err := NewProjectsService(
+			projectsService, err := NewProjectsService(
 				MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
 				UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
 				UpdateProjectResponseTemplate,
-            )
+			)
 			assert.NoError(t, err)
 
 			res, responseMessage, err := projectsService.UpdateProject(context.Background(), tt.arg)
@@ -361,11 +361,11 @@ func TestProjectsService_ListProjects(t *testing.T) {
                 "message": "{{.message}}"
             }`
 
-            projectsService, err := NewProjectsService(
+			projectsService, err := NewProjectsService(
 				MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
 				UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
 				UpdateProjectResponseTemplate,
-            )
+			)
 			assert.NoError(t, err)
 
 			res, err := projectsService.ListProjects(context.Background(), "project-", tt.user)
@@ -674,7 +674,11 @@ func TestProjectsService_MakeRequestPayload(t *testing.T) {
 	storage.On("Get", models.ID(1)).Return(exp, nil)
 
 	authEnforcer := &enforcerMock.Enforcer{}
-	projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, false, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+	projectsService, err := NewProjectsService(
+		MLFlowTrackingURL, storage, authEnforcer, false,
+		UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+		UpdateProjectResponseTemplate,
+	)
 	assert.NoError(t, err)
 
 	payload, err := projectsService.MakeRequestPayload(project, UpdateProjectPayloadTemplate)
@@ -746,9 +750,9 @@ func TestProjectsService_ProcessResponseURL(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 	}
 
-	UpdateProjectResponseTemplate := `{"url": "https://project-test.{{ if eq .domain "development" }}d{{ else if eq .domain "staging" }}s{{ else if eq .domain "production" }}p{{ else }}unknown{{ end }}.test.com/projects/{{.project_id}}/domains/{{.domain}}/executions/{{.name}}"}`
+	UpdateProjectResponseTemplate := `{"url": "https://{{.project_id}}.{{.domain}}.test.com/{{.name}}"}`
 
-	exp := `{"url": "https://project-test.d.test.com/projects/my-project/domains/development/executions/response-url"}`
+	exp := `{"url": "https://my-project.development.test.com/response-url"}`
 
 	storage := &mocks.ProjectRepository{}
 	storage.On("Get", models.ID(1)).Return(exp, nil)

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -115,7 +115,11 @@ func TestProjectsService_CreateProject(t *testing.T) {
 			UpdateProjectPayloadTemplate := ""
 			UpdateProjectResponseTemplate := ""
 
-			projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+            projectsService, err := NewProjectsService(
+                MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
+                UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+                UpdateProjectResponseTemplate,
+            )
 			require.NoError(t, err)
 
 			if tt.expAuthUpdate != nil {
@@ -222,7 +226,8 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 					"status":  "success",
 					"message": "Project updated successfully",
 				}
-				json.NewEncoder(w).Encode(response)
+                err = json.NewEncoder(w).Encode(response)
+                require.NoError(t, err)
 			}))
 			defer server.Close()
 
@@ -240,7 +245,11 @@ func TestProjectsService_UpdateProject(t *testing.T) {
                 "message": "{{.message}}"
             }`
 
-			projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+            projectsService, err := NewProjectsService(
+				MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
+				UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+				UpdateProjectResponseTemplate,
+            )
 			assert.NoError(t, err)
 
 			res, responseMessage, err := projectsService.UpdateProject(context.Background(), tt.arg)
@@ -352,7 +361,11 @@ func TestProjectsService_ListProjects(t *testing.T) {
                 "message": "{{.message}}"
             }`
 
-			projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+            projectsService, err := NewProjectsService(
+				MLFlowTrackingURL, storage, authEnforcer, tt.authEnabled, nil,
+				UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+				UpdateProjectResponseTemplate,
+            )
 			assert.NoError(t, err)
 
 			res, err := projectsService.ListProjects(context.Background(), "project-", tt.user)
@@ -384,7 +397,11 @@ func TestProjectsService_FindById(t *testing.T) {
 	UpdateProjectPayloadTemplate := ""
 	UpdateProjectResponseTemplate := ""
 
-	projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, false, nil, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+	projectsService, err := NewProjectsService(
+		MLFlowTrackingURL, storage, authEnforcer, false, nil,
+		UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+		UpdateProjectResponseTemplate,
+	)
 	assert.NoError(t, err)
 
 	res, err := projectsService.FindByID(id)
@@ -677,7 +694,7 @@ func TestProjectsService_SendUpdateRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(UpdateProjectPayloadTemplate))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -694,7 +711,11 @@ func TestProjectsService_SendUpdateRequest(t *testing.T) {
 	storage.On("Get", models.ID(1)).Return(exp, nil)
 
 	authEnforcer := &enforcerMock.Enforcer{}
-	projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, false, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+	projectsService, err := NewProjectsService(
+		MLFlowTrackingURL, storage, authEnforcer, false,
+		UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+		UpdateProjectResponseTemplate,
+	)
 	assert.NoError(t, err)
 
 	resp, err := projectsService.SendUpdateRequest(UpdateProjectEndpoint, UpdateProjectPayloadTemplate)
@@ -734,7 +755,11 @@ func TestProjectsService_ProcessResponseURL(t *testing.T) {
 
 	authEnforcer := &enforcerMock.Enforcer{}
 
-	projectsService, err := NewProjectsService(MLFlowTrackingURL, storage, authEnforcer, false, UpdateProjectEndpoint, UpdateProjectPayloadTemplate, UpdateProjectResponseTemplate)
+	projectsService, err := NewProjectsService(
+		MLFlowTrackingURL, storage, authEnforcer, false,
+		UpdateProjectEndpoint, UpdateProjectPayloadTemplate,
+		UpdateProjectResponseTemplate,
+	)
 	assert.NoError(t, err)
 
 	result, err := projectsService.ProcessResponseURL(response, UpdateProjectResponseTemplate)

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -156,7 +156,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 		updateProjectEndpoint string
 		updateProjectPayload  string
 		updateProjectResponse string
-		labelsBlacklist       map[string]bool
+		labelsBlacklist       []string
 	}{
 		{
 			"success: auth enabled with update endpoint",
@@ -198,7 +198,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 			"endpoint-url",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 		{
 			"success: auth enabled without update endpoint",
@@ -240,7 +240,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 			"",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 		{
 			"success: auth disabled without endpoint",
@@ -269,7 +269,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 			"",
 			"",
 			"",
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 	}
 	for _, tt := range tests {
@@ -578,7 +578,7 @@ func TestProjectsService_UpdateProjectWithWebhook(t *testing.T) {
 		updateProjectEndpoint string
 		updateProjectPayload  string
 		updateProjectResponse string
-		labelsBlacklist       map[string]bool
+		labelsBlacklist       []string
 	}{
 		{
 			"success: webhook update with update endpoint",
@@ -618,7 +618,7 @@ func TestProjectsService_UpdateProjectWithWebhook(t *testing.T) {
 			"endpoint-url",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 		{
 			"success: webhook update without update endpoint",
@@ -658,7 +658,7 @@ func TestProjectsService_UpdateProjectWithWebhook(t *testing.T) {
 			"",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 	}
 	for _, tt := range tests {
@@ -744,7 +744,7 @@ func TestProjectsService_UpdateProjectWithWebhookEventNotSet(t *testing.T) {
 		updateProjectEndpoint string
 		updateProjectPayload  string
 		updateProjectResponse string
-		labelsBlacklist       map[string]bool
+		labelsBlacklist       []string
 	}{
 		{
 			"success: webhook event ignored with endpoint",
@@ -783,7 +783,7 @@ func TestProjectsService_UpdateProjectWithWebhookEventNotSet(t *testing.T) {
 			"endpoint-url",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 		{
 			"success: webhook event ignored without endpoint",
@@ -822,7 +822,7 @@ func TestProjectsService_UpdateProjectWithWebhookEventNotSet(t *testing.T) {
 			"",
 			`{"project": "{{.Name}}", "administrators": "{{.Administrators}}"}`,
 			`{"status": "{{.status}}", "message": "{{.message}}"}`,
-			map[string]bool{"label1": true, "label2": true},
+			[]string{"label1", "label2"},
 		},
 	}
 	for _, tt := range tests {

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -44,9 +44,9 @@ const config = {
       : true,
   PROJECT_INFO_UPDATE_ENABLED:
     getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false,
-  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "")
-    .split(",")
-    .map(label => label.trim())
+  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || []).map(label =>
+    label.trim()
+  )
 };
 
 export default config;

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -44,7 +44,7 @@ const config = {
       : true,
   PROJECT_INFO_UPDATE_ENABLED:
     getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false,
-  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "t").split(",")
+  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "").split(", ")
 };
 
 export default config;

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -43,7 +43,8 @@ const config = {
       ? getEnv("REACT_APP_ALLOW_CUSTOM_TEAM")
       : true,
   PROJECT_INFO_UPDATE_ENABLED:
-    getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false
+    getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false,
+  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "t").split(",")
 };
 
 export default config;

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -44,7 +44,12 @@ const config = {
       : true,
   PROJECT_INFO_UPDATE_ENABLED:
     getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false,
-  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "").split(", ")
+  LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "")
+    .split(",")
+    .reduce((check, label) => {
+      check[label.trim()] = true;
+      return check;
+    }, {})
 };
 
 export default config;

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -46,10 +46,7 @@ const config = {
     getEnv("REACT_APP_PROJECT_INFO_UPDATE_ENABLED") || false,
   LABELS_BLACKLIST: (getEnv("REACT_APP_LABELS_BLACKLIST") || "")
     .split(",")
-    .reduce((check, label) => {
-      check[label.trim()] = true;
-      return check;
-    }, {})
+    .map(label => label.trim())
 };
 
 export default config;

--- a/ui/packages/app/src/project_setting/form/Labels.js
+++ b/ui/packages/app/src/project_setting/form/Labels.js
@@ -16,8 +16,7 @@ export const Labels = ({
   setLabels,
   setIsValidLabels,
   isValidLabels,
-  isDisabled = false,
-  labelsBlacklist = false
+  isDisabled = false
 }) => {
   const [items, setItems] = useState(
     (e => {
@@ -26,7 +25,8 @@ export const Labels = ({
           ...label,
           idx,
           isKeyValid: true,
-          isValueValid: true
+          isValueValid: true,
+          existsBefore: true
         }));
       } else {
         return [];
@@ -40,7 +40,8 @@ export const Labels = ({
       {
         idx: items.length,
         isKeyValid: false,
-        isValueValid: false
+        isValueValid: false,
+        existsBefore: false
       }
     ];
     setItems(newItems);
@@ -105,6 +106,7 @@ export const Labels = ({
       delete element.isKeyValid;
       delete element.isValueValid;
       delete element.idx;
+      delete element.existsBefore;
       return element;
     });
 
@@ -117,14 +119,14 @@ export const Labels = ({
         {items.map((element, idx) => {
           const isFieldDisabled =
             isDisabled ||
-            (labelsBlacklist && config.LABELS_BLACKLIST[element.key]);
+            (element.existsBefore && config.LABELS_BLACKLIST[element.key]);
           return (
             <EuiFlexItem key={idx}>
               <EuiFlexGroup gutterSize="s">
                 <EuiFlexItem grow={1}>
                   <EuiFieldText
                     placeholder="key"
-                    value={element.key || ""}
+                    value={element.key}
                     onChange={onKeyChange(idx)}
                     isInvalid={!element.isKeyValid}
                     disabled={isFieldDisabled}
@@ -133,7 +135,7 @@ export const Labels = ({
                 <EuiFlexItem grow={1}>
                   <EuiFieldText
                     placeholder="value"
-                    value={element.value || ""}
+                    value={element.value}
                     onChange={onValueChange(idx)}
                     isInvalid={!element.isValueValid}
                     disabled={isFieldDisabled}

--- a/ui/packages/app/src/project_setting/form/Labels.js
+++ b/ui/packages/app/src/project_setting/form/Labels.js
@@ -9,13 +9,15 @@ import {
   EuiFormRow
 } from "@elastic/eui";
 import { isValidK8sLabelKeyValue } from "../../validation/validation";
+import config from "../../config";
 
 export const Labels = ({
   labels,
   setLabels,
   setIsValidLabels,
   isValidLabels,
-  isDisabled = false
+  isDisabled = false,
+  labelsBlacklist = false
 }) => {
   const [items, setItems] = useState(
     (e => {
@@ -107,14 +109,15 @@ export const Labels = ({
     });
 
     setLabels(newLabels);
-
-    console.log(isDisabled || items.length === 0);
   };
 
   return (
     <EuiFormRow isInvalid={!isValidLabels} error={labelError}>
       <EuiFlexGroup direction="column" gutterSize="m">
         {items.map((element, idx) => {
+          const isFieldDisabled =
+            isDisabled ||
+            (labelsBlacklist && config.LABELS_BLACKLIST.includes(element.key));
           return (
             <EuiFlexItem>
               <EuiFlexGroup gutterSize="s">
@@ -124,7 +127,7 @@ export const Labels = ({
                     value={element.key}
                     onChange={onKeyChange(idx)}
                     isInvalid={!element.isKeyValid}
-                    disabled={isDisabled}
+                    disabled={isFieldDisabled}
                   />
                 </EuiFlexItem>
                 <EuiFlexItem grow={1}>
@@ -133,7 +136,7 @@ export const Labels = ({
                     value={element.value}
                     onChange={onValueChange(idx)}
                     isInvalid={!element.isValueValid}
-                    disabled={isDisabled}
+                    disabled={isFieldDisabled}
                   />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
@@ -141,7 +144,7 @@ export const Labels = ({
                     iconType="trash"
                     onClick={removeElement(idx)}
                     color="danger"
-                    disabled={isDisabled}
+                    disabled={isFieldDisabled}
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/ui/packages/app/src/project_setting/form/Labels.js
+++ b/ui/packages/app/src/project_setting/form/Labels.js
@@ -119,7 +119,8 @@ export const Labels = ({
         {items.map((element, idx) => {
           const isFieldDisabled =
             isDisabled ||
-            (element.existsBefore && config.LABELS_BLACKLIST[element.key]);
+            (element.existsBefore &&
+              config.LABELS_BLACKLIST.includes(element.key));
           return (
             <EuiFlexItem key={idx}>
               <EuiFlexGroup gutterSize="s">

--- a/ui/packages/app/src/project_setting/form/Labels.js
+++ b/ui/packages/app/src/project_setting/form/Labels.js
@@ -117,14 +117,14 @@ export const Labels = ({
         {items.map((element, idx) => {
           const isFieldDisabled =
             isDisabled ||
-            (labelsBlacklist && config.LABELS_BLACKLIST.includes(element.key));
+            (labelsBlacklist && config.LABELS_BLACKLIST[element.key]);
           return (
-            <EuiFlexItem>
+            <EuiFlexItem key={idx}>
               <EuiFlexGroup gutterSize="s">
                 <EuiFlexItem grow={1}>
                   <EuiFieldText
                     placeholder="key"
-                    value={element.key}
+                    value={element.key || ""}
                     onChange={onKeyChange(idx)}
                     isInvalid={!element.isKeyValid}
                     disabled={isFieldDisabled}
@@ -133,7 +133,7 @@ export const Labels = ({
                 <EuiFlexItem grow={1}>
                   <EuiFieldText
                     placeholder="value"
-                    value={element.value}
+                    value={element.value || ""}
                     onChange={onValueChange(idx)}
                     isInvalid={!element.isValueValid}
                     disabled={isFieldDisabled}

--- a/ui/packages/app/src/project_setting/project_info/ProjectInfoForm.js
+++ b/ui/packages/app/src/project_setting/project_info/ProjectInfoForm.js
@@ -93,7 +93,6 @@ const ProjectInfoForm = ({ originalProject, fetchUpdates }) => {
               setIsValidLabels={setIsValidLabels}
               isValidLabels={isValidLabels}
               isDisabled={isDisabled}
-              labelsBlacklist={true}
             />
           </EuiFlexItem>
           <EuiSpacer size="m" />

--- a/ui/packages/app/src/project_setting/project_info/ProjectInfoForm.js
+++ b/ui/packages/app/src/project_setting/project_info/ProjectInfoForm.js
@@ -93,6 +93,7 @@ const ProjectInfoForm = ({ originalProject, fetchUpdates }) => {
               setIsValidLabels={setIsValidLabels}
               isValidLabels={isValidLabels}
               isDisabled={isDisabled}
+              labelsBlacklist={true}
             />
           </EuiFlexItem>
           <EuiSpacer size="m" />

--- a/ui/packages/app/src/project_setting/project_info/UpdateProjectInfoModal.js
+++ b/ui/packages/app/src/project_setting/project_info/UpdateProjectInfoModal.js
@@ -6,7 +6,8 @@ import {
   EuiCode,
   EuiBasicTable,
   EuiFlexItem,
-  EuiFlexGroup
+  EuiFlexGroup,
+  EuiLink
 } from "@elastic/eui";
 import { useNavigate } from "react-router-dom";
 
@@ -30,15 +31,25 @@ const UpdateProjectInfoModal = ({
 
   useEffect(() => {
     if (submissionResponse.isLoaded && !submissionResponse.error) {
+      const response = submissionResponse.data.update_status_url;
       closeModal();
       addToast({
         id: "submit-success-create",
         title: "Project Info Updated!",
         color: "success",
-        iconType: "check"
+        iconType: "check",
+        text: (
+          <p>
+            Your project's resource(s) are currently being redeployed, you can
+            check the workflow here:{" "}
+            <EuiLink href={response} target="_blank">
+              Link
+            </EuiLink>
+          </p>
+        )
       });
       fetchUpdates();
-      navigate(`/projects/${submissionResponse.data.id}/settings/project-info`);
+      navigate(`/projects/${project.id}/settings/project-info`);
     }
   }, [navigate, submissionResponse, project, fetchUpdates, closeModal]);
 

--- a/ui/packages/app/src/project_setting/project_info/UpdateProjectInfoModal.js
+++ b/ui/packages/app/src/project_setting/project_info/UpdateProjectInfoModal.js
@@ -38,7 +38,7 @@ const UpdateProjectInfoModal = ({
         title: "Project Info Updated!",
         color: "success",
         iconType: "check",
-        text: (
+        text: response ? (
           <p>
             Your project's resource(s) are currently being redeployed, you can
             check the workflow here:{" "}
@@ -46,7 +46,7 @@ const UpdateProjectInfoModal = ({
               Link
             </EuiLink>
           </p>
-        )
+        ) : null
       });
       fetchUpdates();
       navigate(`/projects/${project.id}/settings/project-info`);


### PR DESCRIPTION
This PR introduces three new configs (to be read from the yaml file) to the MLP API server. The configs that are being added are:

1. Endpoint to be called when the update projects settings endpoint is called
2. Request payload JSON template to be sent to the specified endpoint
3. Response URL template to be sent back to the user

Additionally, a labels blacklist config will be added that hides/prevents the labels contained within to not be modifiable