### PR TITLE
fix(ui): Fix incorrect env var existence check

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -130,6 +130,7 @@ jobs:
           name: api-test
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ./api
+          codecov_yml_path: ../.github/workflows/codecov-config/codecov.yml
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov-config/codecov.yml
+++ b/.github/workflows/codecov-config/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 0.03%

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -1,5 +1,5 @@
 const getEnv = env => {
-  return window.env && window.env[env] ? window.env[env] : process.env[env];
+  return window.env && env in window.env ? window.env[env] : process.env[env];
 };
 
 export const sentryConfig = {


### PR DESCRIPTION
## Context
The following `getEnv` helper function is used to extract React env vars from a web-served `env.js` file or if undefined, the underlying node process. However, the logical check (whether the env var exists in `window`) is inherently problematic, since an env var with the value `false` (e.g. `REACT_APP_IS_FALSE=false`) would cause `window.env[env]` to return false, even if it exists in `window` (i.e. `window.env.REACT_APP_IS_FALSE=false`), thus returning `process.env[env]` instead, which may (in the worst case) have that env var set to `true` instead in the node process.
```js
const getEnv = env => {
  return window.env && window.env[env] ? window.env[env] : process.env[env];
};
```

This PR fixes the if-else condition and uses the same [check](https://github.com/caraml-dev/merlin/blob/main/ui/src/config.js#L21) as the one performed in the Merlin UI:
```js
const getEnv = (env) => {
  return window.env && env in window.env ? window.env[env] : process.env[env];
};
```

TL;DR: `window.env[env]` is not a valid existence check in JS `window.env[env] != env in window.env` 

## Extra
This PR also adds the threshold config for the codecov reports.