### PR TITLE
Minor fixes for webhooks package & project creation

### DIFF
--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -59,10 +59,11 @@ func (c *ProjectsController) CreateProject(r *http.Request, vars map[string]stri
 		// since the current logic creates the Project first before firing
 		// the ProjectCreatedEvent webhook.
 		if errors.As(err, &webhookError) {
-			err := fmt.Errorf(`Project %s was created, 
+			errMsg := fmt.Errorf(`Project %s was created, 
 			but not all webhooks were correctly invoked. 
-			Some additional resources may not have been created successfully : %s`, project.Name, err)
-			return FromError(err)
+			Some additional resources may not have been created successfully`, project.Name)
+			log.Errorf("%s, %s", errMsg, err)
+			return FromError(errMsg)
 		}
 		log.Errorf("error creating project %s: %s", project.Name, err)
 		return FromError(err)

--- a/api/api/projects_api.go
+++ b/api/api/projects_api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/caraml-dev/mlp/api/log"
 	"github.com/caraml-dev/mlp/api/models"
 	apperror "github.com/caraml-dev/mlp/api/pkg/errors"
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
 )
 
 type ProjectsController struct {
@@ -51,7 +52,18 @@ func (c *ProjectsController) CreateProject(r *http.Request, vars map[string]stri
 	user := vars["user"]
 	project.Administrators = addRequester(user, project.Administrators)
 	project, err = c.ProjectsService.CreateProject(r.Context(), project)
+	var webhookError *webhooks.WebhookError
 	if err != nil {
+		// NOTE: Here we are checking if the error is a WebhookError
+		// This is to improve the error message shared with the user,
+		// since the current logic creates the Project first before firing
+		// the ProjectCreatedEvent webhook.
+		if errors.As(err, &webhookError) {
+			err := fmt.Errorf(`Project %s was created, 
+			but not all webhooks were correctly invoked. 
+			Some additional resources may not have been created successfully : %s`, project.Name, err)
+			return FromError(err)
+		}
 		log.Errorf("error creating project %s: %s", project.Name, err)
 		return FromError(err)
 	}

--- a/api/pkg/webhooks/client.go
+++ b/api/pkg/webhooks/client.go
@@ -103,14 +103,14 @@ func (g *simpleWebhookClient) Invoke(ctx context.Context, payload []byte) ([]byt
 			}
 			// check http status code
 			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("response status code %d not 200", resp.StatusCode)
+				return fmt.Errorf("response status code %d not 200, err: %s", resp.StatusCode, content)
 			}
 			return nil
 
 		}, retry.Attempts(uint(g.NumRetries)), retry.Context(ctx),
 	)
 	if err != nil {
-		return nil, err
+		return nil, NewWebhookError(err)
 	}
 	return content, nil
 }

--- a/api/pkg/webhooks/client.go
+++ b/api/pkg/webhooks/client.go
@@ -107,7 +107,7 @@ func (g *simpleWebhookClient) Invoke(ctx context.Context, payload []byte) ([]byt
 			}
 			return nil
 
-		}, retry.Attempts(uint(g.NumRetries)), retry.Context(ctx),
+		}, retry.Attempts(uint(g.NumRetries)), retry.Context(ctx), retry.LastErrorOnly(true),
 	)
 	if err != nil {
 		return nil, NewWebhookError(err)

--- a/api/pkg/webhooks/client.go
+++ b/api/pkg/webhooks/client.go
@@ -152,4 +152,7 @@ func setDefaults(webhookConfig *WebhookConfig) {
 		def := 10
 		webhookConfig.Timeout = &def
 	}
+	if webhookConfig.NumRetries == 0 {
+		webhookConfig.NumRetries = 3
+	}
 }

--- a/api/pkg/webhooks/errors.go
+++ b/api/pkg/webhooks/errors.go
@@ -1,0 +1,29 @@
+package webhooks
+
+import "fmt"
+
+type WebhookError struct {
+	msg string
+	err error
+}
+
+func NewWebhookError(err error) *WebhookError {
+	return &WebhookError{
+		msg: "error invoking webhook",
+		err: err,
+	}
+}
+
+// Implement errors.Error method
+func (e *WebhookError) Error() string {
+	return fmt.Sprintf("%s: %v", e.msg, e.err)
+}
+
+func (e *WebhookError) Unwrap() error {
+	return e.err
+}
+
+func (e *WebhookError) Is(target error) bool {
+	_, ok := target.(*WebhookError)
+	return ok
+}


### PR DESCRIPTION
### Summary
* Add errors.go in webhook package to wrap all errors from the webhooks library as a WebhookError
* This is to enable better error handling, when users are creating or updating their projects when webhooks are enabled.
* Default numRetries set to 3, this prevents the frontend ui from timing out.
* The change in this MR will show this error if the ProjectCreatedEvent webhooks did not succeed:
<img width="1714" alt="image" src="https://github.com/caraml-dev/mlp/assets/20089568/6f366a8b-53c3-4098-a99c-bf9e21c12455">
* For updating projects, this error will appear:
<img width="1700" alt="image" src="https://github.com/caraml-dev/mlp/assets/20089568/b2319b2b-ee1a-4e98-97ad-d3a3ed1c4dab">
