### PR TITLE
chore(ui-lib): Bump up sentry browser package version

### DIFF
--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caraml-dev/ui-lib",
-  "version": "1.7.6",
+  "version": "1.13.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -53,7 +53,7 @@
     "@elastic/eui": "^94.5.2",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
-    "@sentry/browser": "5.15.5",
+    "@sentry/browser": "8.5.0",
     "moment": "^2.30.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
## Context 

In #100, the version of the `sentry/browser` package used in the MLP app UI has been [updated](https://github.com/caraml-dev/mlp/blob/8a02334a463c83aac2daca44864889d6fa63e839/ui/packages/app/package.json#L12) to `v8.5.0`. However, the same wasn't done to the MLP UI library, which is still stuck at `v5.15.5`. 

This PR bumps up the version of `sentry/browser`, and similarly bumps up the version of the MLP UI library, which hasn't been updated for ages (this also allows the CICD pipeline to cut and release a new version of the MLP UI library).
