### PR TITLE
fix(ui): Add query selector to sticky accordion sidebar to the page header

### DIFF
--- a/ui/packages/lib/src/components/accordion_form/AccordionForm.js
+++ b/ui/packages/lib/src/components/accordion_form/AccordionForm.js
@@ -25,7 +25,7 @@ export const AccordionForm = ({
   return (
     <EuiFlexGroup direction="row" gutterSize="none" className="accordionForm">
       <EuiFlexItem grow={false} className="accordionForm--sideNavContainer">
-        <Sticky enabled={true}>
+        <Sticky enabled={true} top={".euiHeader"}>
           <AccordionFormSideNav name={name} sections={sections} />
         </Sticky>
       </EuiFlexItem>


### PR DESCRIPTION
## Context
This PR adds a [query selector](https://www.npmjs.com/package/react-stickynode?activeTab=readme#usage) (see [this](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) for more details too) to the new sticky wrapper we're using to stick the accordion sidebar to the bottom of the MLP page header so that it doesn't get hidden behind it:

Before:
![ScreenRecording2024-07-16at12 02 49-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/63bfad36-2914-41a1-9e49-84b9d9a533b7)

After:
![ScreenRecording2024-07-16at12 02 02-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6ef1bf5d-562f-4be5-8838-5d4dffa03510)