### PR TITLE
chore(ui-lib): Bump up caraml ui-lib version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caraml-dev/ui-lib",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caraml-dev/ui-lib",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
## Context
This PR bumps up the version of `caraml-dev/ui-lib` so that we can import latest changes to it in other CaraML UI, such as MLP, Turing, Merlin, etc. (I forgot to have this bumped in PR #110 😑 I'll need to open another PR to update the version of `caraml-dev/ui-lib` used in the MLP UI after this PR has been merged).