### PR TITLE
chore: update docker compose to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,27 +149,27 @@ local-env: local-db start-keto start-vault
 .PHONY: local-db
 local-db:
 	@echo "> Starting up DB ..."
-	@docker-compose up -d postgres
+	@docker compose up -d postgres
 
 .PHONY: start-keto
 start-keto:
 	@echo "> Starting up keto server ..."
-	@docker-compose up -d keto
+	@docker compose up -d keto
 
 .PHONY: start-vault
 start-vault:
 	@echo "> Starting up vault server ..."
-	@docker-compose up -d vault
+	@docker compose up -d vault
 
 .PHONY: stop-docker
 stop-docker:
 	@echo "> Stopping Docker compose ..."
-	@docker-compose down
+	@docker compose down
 
 .PHONY: swagger-ui
 swagger-ui:
 	@echo "> Starting up Swagger UI ..."
-	@docker-compose up -d swagger-ui
+	@docker compose up -d swagger-ui
 
 .PHONY: version
 version:


### PR DESCRIPTION
## Context

Docker Compose V1 has [been removed from Github Runners](https://github.com/actions/runner-images/issues/9692) since 29th July, which resulted in MLP integration failing ([ex](https://github.com/caraml-dev/mlp/actions/runs/10258637631/job/28381776424)), as it cannot found the command `docker-compose`. This PR is intended to fix this issue by updating into the Docker Compose V2 command `docker compose`