### PR TITLE
chore: use ctx background when calling webhook async

### DIFF
--- a/api/pkg/webhooks/manager.go
+++ b/api/pkg/webhooks/manager.go
@@ -88,7 +88,7 @@ func (w *SimpleWebhookManager) InvokeWebhooks(
 	for _, client := range asyncClients {
 		go func(client WebhookClient) {
 			// Ignore the response from async webhooks
-			if _, err := client.Invoke(ctx, originalPayload); err != nil {
+			if _, err := client.Invoke(context.Background(), originalPayload); err != nil {
 				return
 			}
 		}(client)


### PR DESCRIPTION
## Context

When trying to call a webhook within an API call, the context that usually will be passed is request context. Issue is, this context will expire when the client API call is done (either by timeout, cancel, or finished process), therefore when calling the async webhook with `NewRequestWithContext` it might produce an error because the request will not wait for aync call, as it's called in another go routine. 

To mitigate this issue, the async webhook call will use `context.Background()` instead. 