### PR TITLE
fix: init webhook validation check

### DIFF
--- a/api/pkg/webhooks/manager_test.go
+++ b/api/pkg/webhooks/manager_test.go
@@ -130,7 +130,7 @@ func TestInitializeWebhooks(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Config enabled with multiple webhooks",
+			name: "Config enabled with multiple webhooks all sync",
 			cfg: &Config{
 				Enabled: true,
 				Config: map[EventType][]WebhookConfig{
@@ -145,6 +145,30 @@ func TestInitializeWebhooks(t *testing.T) {
 							Name:   "webhook2",
 							URL:    "http://example.com",
 							Method: "POST",
+						},
+					},
+				},
+			},
+			eventList:     []EventType{"event1"},
+			expectedError: false,
+		},
+		{
+			name: "Config enabled with multiple webhooks all async",
+			cfg: &Config{
+				Enabled: true,
+				Config: map[EventType][]WebhookConfig{
+					"event1": {
+						{
+							Name:   "webhook1",
+							URL:    "http://example.com",
+							Method: "POST",
+							Async:  true,
+						},
+						{
+							Name:   "webhook2",
+							URL:    "http://example.com",
+							Method: "POST",
+							Async:  true,
 						},
 					},
 				},
@@ -248,17 +272,40 @@ func TestInitializeWebhooks(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "Config enabled with multiple webhooks with sync and async",
+			cfg: &Config{
+				Enabled: true,
+				Config: map[EventType][]WebhookConfig{
+					"event1": {
+						{
+							Name:   "webhook2",
+							URL:    "http://example.com",
+							Method: "POST",
+							Async:  true,
+						},
+						{
+							Name:          "webhook1",
+							URL:           "http://example.com",
+							Method:        "POST",
+							FinalResponse: true,
+						},
+					},
+				},
+			},
+			eventList:     []EventType{"event1"},
+			expectedError: false,
+		},
+		{
 			name: "Config enabled with multiple webhooks with sync and async, fail with duplicate names",
 			cfg: &Config{
 				Enabled: true,
 				Config: map[EventType][]WebhookConfig{
 					"event1": {
 						{
-							Name:        "webhook2",
-							URL:         "http://example.com",
-							Method:      "POST",
-							UseDataFrom: "webhook1",
-							Async:       true,
+							Name:   "webhook2",
+							URL:    "http://example.com",
+							Method: "POST",
+							Async:  true,
 						},
 						{
 							Name:          "webhook1",
@@ -271,6 +318,31 @@ func TestInitializeWebhooks(t *testing.T) {
 							URL:    "http://example.com",
 							Method: "POST",
 							Async:  true,
+						},
+					},
+				},
+			},
+			eventList:     []EventType{"event1"},
+			expectedError: true,
+		},
+		{
+			name: "Config enabled with multiple webhooks fail (no final response set for sync webhook)",
+			cfg: &Config{
+				Enabled: true,
+				Config: map[EventType][]WebhookConfig{
+					"event1": {
+						{
+							Name:          "webhook1",
+							URL:           "http://example.com",
+							Method:        "POST",
+							FinalResponse: true,
+							Async:         true,
+						},
+						{
+							Name:   "webhook2",
+							URL:    "http://example.com",
+							Method: "POST",
+							Async:  false,
 						},
 					},
 				},


### PR DESCRIPTION
# Background
When trying to initiate all async webhook, the webhook validation check throw an error that "at least 1 sync client must have finalResponse set to true". On the other hands, if trying to setup multiple sync & async client, where only async client has `finalResponse=true`, the validation will pass

# Changes

- Validate there's no duplicate webhook names for all client
- Only check final response set to true and if a client used response from another webhook, the used webhook must be defined beforehand only for _sync_ client (as response from async client will not be used)
- Removing [this line](https://github.com/caraml-dev/mlp/blob/main/api/pkg/webhooks/manager.go#L184-L190) as `useIdx > idx` will never be true/reached, because if `useIdx > idx` then [this](https://github.com/caraml-dev/mlp/blob/fix_init_webhook_validation/api/pkg/webhooks/manager.go#L201) must have been true then throw an error
- Adding some testcases 